### PR TITLE
Bind.hx: remove unnecessary .toString() in trace()

### DIFF
--- a/assets/Bind.hx
+++ b/assets/Bind.hx
@@ -7,6 +7,6 @@ class Bind {
 		f(1);
 		f(2);
 		f(3);
-		trace(map.toString()); // {1 => 12, 2 => 12, 3 => 12}
+		trace(map); // {1 => 12, 2 => 12, 3 => 12}
 	}
 }


### PR DESCRIPTION
Has been compiled to confirm that the output is indeed the same.
