### PR TITLE
Removed line about single extension limitation on structure

### DIFF
--- a/03-type-system.tex
+++ b/03-type-system.tex
@@ -46,7 +46,6 @@ The greater-than operator \expr{>} denotes that an extension of \type{Iterable$<
 
 In order to be compatible with \type{IterableWithLength$<$T$>$}, a type then must be compatible with \type{Iterable$<$T$>$} and also provide a read-only \expr{length} property of type \type{Int}. The example assigns an \type{Array}, which happens to fulfill these requirements.
 
-There may only be a single extension on a structure, so extensions can be understood as an \tref{inheritance}{types-class-inheritance} mechanism for structures.
 
 
 


### PR DESCRIPTION
I've removed a line that wasn't up-to-date anymore as it is now possible to define multiple extensions on a single structure. Please update the documentation accordingly as I myself am not sure about where and how to document that feature.
