### PR TITLE
Update 02-types.tex

### DIFF
--- a/02-types.tex
+++ b/02-types.tex
@@ -214,7 +214,7 @@ function opt( ?z : Int = -1) {...}
 \end{lstlisting}
 \todo{Is there a difference between \type{?y : Int} and \type{y : Null$<$Int$>$} or can you even do the latter? Some more explanation and examples with native optional and Haxe optional arguments and how they relate to nullability would be nice.}
 
-\trivia{Argument vs Parameter}{In some other programming languages, \emph{argument} and \emph{parameter} are used interchangably.  In Haxe, \emph{argument} is used when referring to methods, and \emph{parameter} refers to \Fullref{type-system-type-parameters}.}
+\trivia{Argument vs Parameter}{In some other programming languages, \emph{argument} and \emph{parameter} are used interchangably.  In Haxe, \emph{argument} is used when referring to methods, and \emph{parameter} refers to \tref{Type Parameters}{type-system-type-parameters}.}
 
 
 \section{Class Instance}


### PR DESCRIPTION
This page (http://haxe.org/manual/types-nullability-optional-arguments.html) has a bad link when trying to click "Type Parameters" ... I believe the issue is that \Fullref is resolving to an *.md URL, not an *.html URL.

Based on a cursory look of other content in the page, changing it to \tref may fix it?
