### PR TITLE
Fix incorrect variable name in 02-types.tex

### DIFF
--- a/02-types.tex
+++ b/02-types.tex
@@ -641,7 +641,7 @@ We can derive the following from this example:
 
 \begin{itemize}
 	\item The keyword \expr{abstract} denotes that we are declaring an abstract type.
-	\item \type{Abstract} is the name of the abstract and could be anything conforming to the rules for type identifiers.
+	\item \type{AbstractInt} is the name of the abstract and could be anything conforming to the rules for type identifiers.
 	\item Enclosed in parenthesis \expr{()} is the \emph{underlying type} \type{Int}.
 	\item Enclosed in curly braces \expr{$\left\{\right\}$} are the fields,
 	\item which are a constructor function \expr{new} accepting one argument \expr{i} of type \type{Int}.


### PR DESCRIPTION
The text said "Abstract" but should have been "AbstractInt" to match the code sample.
This is near the beginning of section 2.8.
http://haxe.org/manual/types-abstract.html
