### PR TITLE
Small typo fix on 04-class-field subsection Visibility

### DIFF
--- a/04-class-field.tex
+++ b/04-class-field.tex
@@ -247,7 +247,7 @@ Omitting the visibility modifier usually defaults the visibility to \expr{privat
 
 \begin{enumerate}
 	\item If the class is declared as \expr{extern}.
-	\item If the field id declared on an \tref{interface}{types-interfaces}.
+	\item If the field is declared on an \tref{interface}{types-interfaces}.
 	\item If the field \tref{overrides}{class-field-overriding} a public field.
 \end{enumerate}
 


### PR DESCRIPTION
Really small, only one letter :)
