### PR TITLE
Editing some typos and doubled words

### DIFF
--- a/03-type-system.tex
+++ b/03-type-system.tex
@@ -200,7 +200,7 @@ Apparently, an \type{Array<Child>} cannot be assigned to an \type{Array<Base>}, 
 
 \haxe{assets/Variance2.hx}
 
-Here we subvert the type checker by using a \tref{cast}{expression-cast}, thus allowing the assignment in line 12. With that we hold a reference \expr{bases} to the original array, typed as \type{Array<Base>}. This allows pushing another type compatible with \type{Base} (\type{OtherChild}) onto that array. However, our original reference \expr{children} is still of type \type{Array<Child>} and things go bad when we encounter the \type{OtherChild} instance in one of its elements while iterating.
+Here we subvert the type checker by using a \tref{cast}{expression-cast}, thus allowing the assignment after the commented line. With that we hold a reference \expr{bases} to the original array, typed as \type{Array<Base>}. This allows pushing another type compatible with \type{Base} (\type{OtherChild}) onto that array. However, our original reference \expr{children} is still of type \type{Array<Child>} and things go bad when we encounter the \type{OtherChild} instance in one of its elements while iterating.
 
 If \type{Array} had no \expr{push()} method and no other means of modification, the assignment would be safe because no incompatible type could be added to it. In Haxe, we can achieve this by restricting the type accordingly using \tref{structural subtyping}{type-system-structural-subtyping}:
 

--- a/04-class-field.tex
+++ b/04-class-field.tex
@@ -303,6 +303,6 @@ Dynamic fields cannot be \expr{inline} for obvious reasons: While inlining is do
 \subsection{Override}
 \label{class-field-override}
 
-The access modifier \expr{override} is required when a field is declared which also exists on a \tref{parent class}{types-class-inheritance}. Its purpose is to ensure that the author of a class is aware of the override as this may not always be obvious in large class hierarchies. Likewise, having \expr{override} on a field which does not actually override anything (e.g. due to a misspelled field name) triggers an error as well.
+The access modifier \expr{override} is required when a field is declared which also exists on a \tref{parent class}{types-class-inheritance}. Its purpose is to ensure that the author of a class is aware of the override as this may not always be obvious in large class hierarchies. Likewise, having \expr{override} on a field which does not actually override anything (e.g. due to a misspelled field name) triggers an error.
 
 The effects of overriding fields are detailed in \Fullref{class-field-overriding}. This modifier is only allowed on \tref{method}{class-field-method} fields.

--- a/04-class-field.tex
+++ b/04-class-field.tex
@@ -181,7 +181,7 @@ Methods are identified by the \expr{function} keyword. We can also learn that th
 	\item have an argument list (here: empty \expr{()}),
 	\item have a return type (here: \type{Void}),
 	\item may have \tref{access modifiers}{class-field-access-modifier} (here: \expr{static} and \expr{public}) and
-	\item may have an expression (here: \expr{\{trace(trace("Hello World");)\}}).
+	\item may have an expression (here: \expr{\{trace("Hello World");\}}).
 \end{enumerate}
 
 We can also look at the next example to learn more about arguments and return types:

--- a/04-class-field.tex
+++ b/04-class-field.tex
@@ -60,7 +60,7 @@ Read access and write access are directly reflected in the syntax, as the follow
 
 \haxe{assets/Property.hx}
 
-For the most part, the syntax is similar to variable syntax, and the same rules indeed apply. Properties are identified by:
+For the most part, the syntax is similar to variable syntax, and the same rules indeed apply. Properties are identified by
 
 \begin{itemize}
 	\item the opening parenthesis \expr{(} after the field name,

--- a/04-class-field.tex
+++ b/04-class-field.tex
@@ -60,7 +60,7 @@ Read access and write access are directly reflected in the syntax, as the follow
 
 \haxe{assets/Property.hx}
 
-For the most part, the syntax is similar to variable syntax, and the same rules indeed apply. Properties are identified by
+For the most part, the syntax is similar to variable syntax, and the same rules indeed apply. Properties are identified by:
 
 \begin{itemize}
 	\item the opening parenthesis \expr{(} after the field name,

--- a/05-expressions.tex
+++ b/05-expressions.tex
@@ -442,7 +442,7 @@ In this example we first cast a class instance of type \type{Child1} to \type{Ba
 
 The Haxe compiler guarantees that an exception of type \type{String} is \tref{thrown}{expression-throw} in this case. This exception can be caught using a \tref{\expr{try/catch} block}{expression-try-catch}.
 
-Safe casts have a runtime overhead. It is important to understand the the compiler already generates type checks, so it is redundant to add manual checks, e.g. using \expr{Std.is}. The intended usage is to try the safe cast and catch the \type{String} exception.
+Safe casts have a runtime overhead. It is important to understand that the compiler already generates type checks, so it is redundant to add manual checks, e.g. using \expr{Std.is}. The intended usage is to try the safe cast and catch the \type{String} exception.
 
 
 \section{type check}

--- a/06-language-features.tex
+++ b/06-language-features.tex
@@ -383,7 +383,7 @@ Line 4 binds the function \expr{map.set} to a variable named \expr{f}, and appli
 
 A call to \expr{f(1)} then actually invokes \expr{map.set(1, "12")}, the calls to \expr{f(2)} and \expr{f(3)} are analogous. The last line proves that all three indices indeed are mapped to the value \expr{"12"}.
 
-The underscore \expr{_} can be skipped for trailing arguments, so the the first argument could be bound through \expr{map.set.bind(1)}, yielding a \expr{String->Void} function that sets a new value for index \expr{1} on invocation.
+The underscore \expr{_} can be skipped for trailing arguments, so the first argument could be bound through \expr{map.set.bind(1)}, yielding a \expr{String->Void} function that sets a new value for index \expr{1} on invocation.
 
 \trivia{Callback}{Prior to Haxe 3, Haxe used to know a \expr{callback}-keyword which could be called with a function argument followed by any number of binding arguments. The name originated from a common usage were a callback-function is created with the this-object being bound.\\
 Callback would allow binding of arguments only from left to right as there was no support for the underscore \expr{_}. The choice to use an underscore was controversial and several other suggestions were made, none of which were considered superior. After all, the underscore \expr{_} at least looks like it's saying ``fill value in here'', which nicely describes its semantics.}

--- a/06-language-features.tex
+++ b/06-language-features.tex
@@ -13,7 +13,7 @@ This example demonstrates usage of conditional compilation:
 
 \haxe{assets/ConditionalCompilation.hx}
 
-Compiling this without any flags will leave only the \expr{trace("ok");} line in the body of the \expr{main} method. The other branches are discarded while parsing the file. As a consequence, these branches must still contain valid Haxe syntax, but the code is not type-checked.
+Compiling this without any flags will leave only the \expr{trace("ok");} line in the body of the \expr{main} method. The other branches are discarded while parsing the file. These other branches must still contain valid Haxe syntax, but the code is not type-checked.
 
 The conditions after \expr{\#if} and \expr{\#elseif} allow the following expressions:
 

--- a/08-compiler-features.tex
+++ b/08-compiler-features.tex
@@ -173,7 +173,7 @@ The type \type{haxe.rtti.Rtti} has been introduced in order to simplify working 
 	\item[doc:] The documentation of the field. This information is only available if the \tref{compiler flag}{define-compiler-flag} \expr{-D use_rtti_doc} was in place. Otherwise, or if the field has no documentation, the value is \expr{null}.
 	\item[get:] The \tref{read access behavior}{define-read-access} of the field.
 	\item[set:] The \tref{write access behavior}{define-write-access} of the field.
-	\item[params:] \item[params:] An array of strings representing the names of the \tref{type parameters}{type-system-type-parameters} the field has. As of Haxe 3.2.0, this does not include the \tref{constraints}{type-system-type-parameter-constraints}.
+	\item[params:] An array of strings representing the names of the \tref{type parameters}{type-system-type-parameters} the field has. As of Haxe 3.2.0, this does not include the \tref{constraints}{type-system-type-parameter-constraints}.
 	\item[platforms:] A list of strings representing the targets where the field is available.
 	\item[meta:] The meta data the field was annotated with.
 	\item[line:] The line number where the field is defined. This information is only available if the field has an expression. Otherwise the value is \expr{null}.

--- a/09-macros.tex
+++ b/09-macros.tex
@@ -167,7 +167,7 @@ The following example demonstrates type building. Note that it is split up into 
 \haxe{assets/TypeBuildingMacro.hx}
 \haxe{assets/TypeBuilding.hx}
 
-The \expr{build} method of \type{TestBuildingMacro} performs three steps:
+The \expr{build} method of \type{TypeBuildingMacro} performs three steps:
 
 \begin{enumerate}
 	\item It obtains the build fields using \expr{Context.getBuildFields()}.


### PR DESCRIPTION
Thank you for the language and the manual, it is an amazing work!
The markdown does not show line numbers as the pdf, so I removed reference to line number in one place, the rest are repeated words or repeated meaning. 
It should be only 9 changes, but 12 are seen... only by opening some of the files in vim, last lines are changed in a non-visible way. (I am new to all these things besides haxe: vim, git and github, so please forgive if that is inconvenient)
