### PR TITLE
Clean up haxelib.json

### DIFF
--- a/11-haxelib.tex
+++ b/11-haxelib.tex
@@ -43,20 +43,15 @@ The following JSON is a simple example of a haxelib.json:
 \begin{lstlisting}
 {
   "name": "useless_lib",
-  "url" :
-	  "https://github.com/jasononeil/useless/",
+  "url" : "https://github.com/jasononeil/useless/",
   "license": "MIT",
   "tags": ["cross", "useless"],
-  "description":
-	  "This library is useless in the same way on
-		every platform",
+  "description": "This library is useless in the same way on every platform.",
   "version": "1.0.0",
-  "releasenote":
-	  "Initial release, everything is working
-		correctly",
+  "releasenote": "Initial release, everything is working correctly.",
   "contributors": ["Juraj","Jason","Nicolas"],
   "dependencies": {
-    "tink_macros": "",
+    "tink_macro": "",
     "nme": "3.5.5"
   }
 }


### PR DESCRIPTION
json doesn't allow multiline string.
`tink_macros` should be `tink_macro`.