### PR TITLE
Added Global Compiler Flags table

### DIFF
--- a/06-language-features.tex
+++ b/06-language-features.tex
@@ -27,6 +27,88 @@ The conditions after \expr{\#if} and \expr{\#elseif} allow the following express
 
 An exhaustive list of all built-in defines can be obtained by invoking the Haxe Compiler with the \expr{--help-defines} argument. The Haxe Compiler allows multiple \expr{-D} flags per compilation.
 
+\subsection{Global Compiler Flags}
+\label{lf-condition-compilation-flags}
+
+Starting from Haxe 3.0, you can get the list of supported compiler flags by running \expr{haxe --help-defines}
+
+\begin{center}
+\begin{tabular}{| l | l |}
+	\hline
+	\multicolumn{2}{|c|}{Global Compiler Flags} \\ \hline
+	Flag &  Description \\ \hline
+	\expr{absolute-path} &  Print absolute file path in trace output \\
+	\expr{advanced-telemetry}  &  Allow the SWF to be measured with Monocle tool \\
+	\expr{as3} &  Defined when outputing flash9 as3 source code \\
+	\expr{check-xml-proxy}  &  Check the used fields of the xml proxy \\
+	\expr{core-api}  &  Defined in the core api context \\
+	\expr{cppia}  &  Generate experimental cpp instruction assembly \\
+	\expr{dce}  &  The current \tref{Dead Code Elimination}{cr-dce} mode \\
+	\expr{dce-debug}  &  Show \tref{Dead Code Elimination}{cr-dce} log \\
+	\expr{debug}  &  Activated when compiling with -debug \\
+	\expr{display}  &  Activated during completion \\
+	\expr{dll-export}  &  GenCPP experimental linking \\
+	\expr{dll-import}  &  GenCPP experimental linking \\
+	\expr{doc-gen}  &  Do not perform any removal/change in order to correctly generate documentation \\
+	\expr{dump}  &  Dump the complete typed AST for internal debugging \\
+	\expr{dump-dependencies}  &  Dump the classes dependencies \\
+	\expr{fdb}  &  Enable full flash debug infos for FDB interactive debugging \\
+	\expr{flash-strict}  &  More strict typing for flash target \\
+	\expr{flash-use-stage}  &  Keep the SWF library initial stage \\
+	\expr{format-warning}  &  Print a warning for each formated string. for 2.x compatibility \\
+	\expr{gencommon-debug}  &  GenCommon internal \\
+	\expr{haxe-boot}  &  Given the name 'haxe' to the flash boot class instead of a generated name \\
+	\expr{haxe-ver}  &  The current Haxe version value \\
+	\expr{hxcpp-api-level}  &  Provided to allow compatibility between hxcpp versions \\
+	\expr{include-prefix}  &  prepend path to generated include files \\
+	\expr{interp}  &  The code is compiled to be run with \expr{--interp} \\
+	\expr{java-ver=[version:5-7]}  & Sets the Java version to be targeted \\
+	\expr{js-classic}  &  Don't use a function wrapper and strict mode in JS output \\
+	\expr{js-es5}  &  Generate JS for ES5-compliant runtimes \\
+	\expr{js-flatten}  &  Generate classes to use fewer object property lookups \\
+	\expr{macro} & Defined when we compile code in the \tref{macro context}{macro} \\
+	\expr{macro-times} & Display per-macro timing when used with \expr{--times} \\
+	\expr{neko-source} & Output neko source instead of bytecode \\
+	\expr{neko-v1} &  Keep Neko 1.x compatibility \\
+	\expr{net-target=<name>}  &  Sets the .NET target. Defaults to net. xbox, micro \_(Micro Framework\_, compact \_(Compact Framework)\_ are some valid values  \\
+	\expr{net-ver=<version:20-45>}  &  Sets the .NET version to be targeted \\
+	\expr{network-sandbox}  &  Use local network sandbox instead of local file access one \\
+	\expr{no-compilation}  &  Disable CPP final compilation \\
+	\expr{no-copt}  &  Disable completion optimization \_(for debug purposes)\_ \\
+	\expr{no-debug}  &  Remove all debug macros from cpp output \\
+	\expr{no-deprecation-warnings} & Do not warn if fields annotated with \expr{@:deprecated} are used \\
+	\expr{no-flash-override}  &  Change overrides on some basic classes into HX suffixed methods flash only \\
+	\expr{no-inline}  &  Disable \tref{inlining}{class-field-inline} \\
+	\expr{no-macro-cache}  &  Disable macro context caching \\
+	\expr{no-opt}  &  Disable optimizations \\
+	\expr{no-pattern-matching}  &  Disable \tref{pattern matching}{lf-pattern-matching} \\
+	\expr{no-root}  &  GenCS internal \\
+	\expr{no-swf-compress}  &  Disable SWF output compression \\
+	\expr{no-traces}  &  Disable all \expr{trace} calls \\
+	\expr{php-prefix}  &  Compiled with \expr{--php-prefix} \\
+	\expr{real-position}  &  Disables haxe source mapping when targetting C\# \\
+	\expr{replace-files}  &  GenCommon internal \\
+	\expr{scriptable}  &  GenCPP internal \\
+	\expr{shallow-expose}  &  Expose types to surrounding scope of Haxe generated closure without writing to window object \\
+	\expr{source-map-content}  &  Include the hx sources as part of the JS source map \\
+	\expr{swc}  &  Output a SWC instead of a SWF \\
+	\expr{swf-compress-level=<level:1-9>}  &  Set the amount of compression for the SWF output \\
+	\expr{swf-debug-password=<yourPassword>}  &  Set a password for debugging. The password field is encrypted by using the MD5 algorithm and prevents unauthorised debugging of your swf. Without this flag -D fdb will use no password. \\
+	\expr{swf-direct-blit}  &  Use hardware acceleration to blit graphics \\
+	\expr{swf-gpu}  &  Use GPU compositing features when drawing graphics \\
+	\expr{swf-mark}  &  GenSWF8 internal \\
+	\expr{swf-metadata=<file.xml>}  &  Include contents of <file.xml> as metadata in the swf. \\
+	\expr{swf-preloader-frame}  &  Insert empty first frame in swf. To be used together with \expr{-D flash-use-stage} and \expr{-swf-lib} \\
+	\expr{swf-protected}  &  Compile Haxe private as protected in the SWF instead of public \\
+	\expr{swf-script-timeout}  &  Maximum ActionScript processing time before script stuck dialog box displays (in seconds) \\
+	\expr{swf-use-doabc}  &  Use DoAbc swf-tag instead of DoAbcDefine \\
+	\expr{sys}  &  Defined for all system platforms \\
+	\expr{unsafe}  &  Allow unsafe code when targeting C\# \\
+	\expr{use-nekoc}  &  Use nekoc compiler instead of internal one \\
+	\expr{use-rtti-doc}  &  Allows access to documentation during compilation \\
+	\expr{vcproj}  &  GenCPP internal \\
+\end{tabular}
+\end{center}
 
 \section{Externs}
 \label{lf-externs}
@@ -477,7 +559,7 @@ Starting from Haxe 3.0, you can get the list of defined compiler metadata by run
 	@:from   &  Specifies that the field of the abstract is a cast operation from the type identified in the function. See \tref{Implicit Casts}{types-abstract-implicit-casts}  &  all \\
 	@:functionCode  &     &  cpp \\
 	@:functionTailCode  &    &  cpp \\
-	@:generic &  Marks a class or class field as \tref{generic}{type-system-generic-type-parameter-construction} so each type parameter combination generates its own type/field  &  all \\
+	@:generic &  Marks a class or class field as \tref{generic}{type-system-generic} so each type parameter combination generates its own type/field  &  all \\
 	@:genericBuild  &  Builds instances of a type using the specified macro   &  all \\
 	@:getter \_(Class field name)\_  &  Generates a native getter function on the given field   &  flash \\
 	@:hack   &  Allows extending classes marked as \expr{@:final}  &  all \\


### PR DESCRIPTION
Grabbed from haxe 3.1.3 --help-defines

+ also fixes link in to generic in meta-table