### PR TITLE
Updated generic class example

### DIFF
--- a/03-type-system.tex
+++ b/03-type-system.tex
@@ -121,16 +121,18 @@ It seems unusual to see the explicit type \type{MyArray<String>} here as we usua
 
 \begin{lstlisting}
 (function () { "use strict";
-var Main = function() { }
-Main.main = function() {
-	var a = new MyArray_String();
-	var b = new MyArray_Int();
-}
-var MyArray_Int = function() {
+var Test = function() { };
+Test.main = function() {
+	var a = new MyValue_String("Hello");
+	var b = new MyValue_Int(5);
 };
-var MyArray_String = function() {
+var MyValue_Int = function(value) {
+	this.value = value;
 };
-Main.main();
+var MyValue_String = function(value) {
+	this.value = value;
+};
+Test.main();
 })();
 \end{lstlisting}
 

--- a/assets/GenericClass.hx
+++ b/assets/GenericClass.hx
@@ -6,7 +6,7 @@ class MyValue<T> {
 	}
 }
 
-class Test {
+class Main {
 	static public function main() {
 		var a = new MyValue<String>("Hello");
 		var b = new MyValue<Int>(42);

--- a/assets/GenericClass.hx
+++ b/assets/GenericClass.hx
@@ -1,11 +1,14 @@
 @:generic
-class MyArray<T> {
-  public function new() { }
+class MyValue<T> {
+	public var value:T;
+		public function new(value:T) {
+		this.value = value;
+	}
 }
 
-class Main {
-  static public function main() {
-    var a = new MyArray<String>();
-    var b = new MyArray<Int>();
-  }
+class Test {
+	static public function main() {
+		var a = new MyValue<String>("Hello");
+		var b = new MyValue<Int>(42);
+	}
 }


### PR DESCRIPTION
The old example gives the impression that the MyArray was like an array-ish type, which is not the case. try.haxe also uses this example.