### PR TITLE
Give a better example for programmatic text replacement with EReg.map().

### DIFF
--- a/10-std.tex
+++ b/10-std.tex
@@ -230,11 +230,10 @@ A regular expression can also be used to split a string into several substrings:
 \subsection{Map}
 \label{std-regex-map}
 
-The \expr{map} method of a regular expression object can be used to replace matched substrings using a custom function:
+The \expr{map} method of a regular expression object can be used to replace matched substrings using a custom function.  This function takes a regular expression object as its first argument so we may use it to get additional information about the match being done and do conditional replacement.  For example:
 
 \haxe{assets/ERegMap.hx}
 
-This function takes a regular expression object as its first argument so we may use it to get additional information about the match being done.
 
 \subsection{Implementation Details}
 \label{std-regex-implementation-details}

--- a/10-std.tex
+++ b/10-std.tex
@@ -230,7 +230,7 @@ A regular expression can also be used to split a string into several substrings:
 \subsection{Map}
 \label{std-regex-map}
 
-The \expr{map} method of a regular expression object can be used to replace matched substrings using a custom function.  This function takes a regular expression object as its first argument so we may use it to get additional information about the match being done and do conditional replacement.  For example:
+The \expr{map} method of a regular expression object can be used to replace matched substrings using a custom function. This function takes a regular expression object as its first argument so we may use it to get additional information about the match being done and do conditional replacement. For example:
 
 \haxe{assets/ERegMap.hx}
 
@@ -251,7 +251,7 @@ Regular Expressions are implemented:
 \section{Math}
 \label{std-math}
 
-Haxe includes a floating point math library for some common mathematical operations.  Most of the fuctions operate on and return \type{floats}.  However, an \type{Int} can be used where a \type{Float} is expected, and Haxe also converts \type{Int} to \type{Float} during most numeric operations  (see \Fullref{types-numeric-operators} for more details).
+Haxe includes a floating point math library for some common mathematical operations. Most of the functions operate on and return \type{floats}. However, an \type{Int} can be used where a \type{Float} is expected, and Haxe also converts \type{Int} to \type{Float} during most numeric operations  (see \Fullref{types-numeric-operators} for more details).
 
 Here are some example uses of the math library.  See the \href{http://api.haxe.org/Math.html}{Math API} for all available functions.
 

--- a/assets/ERegMap.hx
+++ b/assets/ERegMap.hx
@@ -1,6 +1,6 @@
 class Main {
   static function main() {
-    var r = new EReg("(dog|fox)", "g");
+    var r = ~/(dog|fox)/g;
     var s = "The quick brown fox jumped over the lazy dog.";
     var s2 = r.map(s, function(r) {
         var match = r.matched(0);

--- a/assets/ERegMap.hx
+++ b/assets/ERegMap.hx
@@ -1,10 +1,15 @@
 class Main {
   static function main() {
-    var r = ~/world/;
-    var s = "Hello, world!";
+    var r = new EReg("(dog|fox)", "g");
+    var s = "The quick brown fox jumped over the lazy dog.";
     var s2 = r.map(s, function(r) {
-    return "Haxe";
+        var match = r.matched(0);
+        switch (match) {
+            case 'dog': return 'fox';
+            case 'fox': return 'dog';
+            default: throw 'Unknown animal: $match';
+        };
     });
-  trace(s2); // Hello, Haxe!
+  trace(s2); // The quick brown dog jumped over the lazy fox.
   }
 }


### PR DESCRIPTION
This is just a small enhancement to the EReg.map documentation that makes things a little more understandable for new Haxe developers.