### PR TITLE
Convert: \slash, \noindent and empty \mbox

### DIFF
--- a/convert/src/LatexCommand.hx
+++ b/convert/src/LatexCommand.hx
@@ -38,6 +38,8 @@ enum LatexCommand {
 	CTextwidth;
 	CCaption;
 	CInput;
+	CNoindent;
+	CMbox;
 
 	CTextless;
 	CTextgreater;
@@ -47,4 +49,5 @@ enum LatexCommand {
 	CTextit;
 	CTextbf;
 	CTextasciicircum;
+	CSlash;
 }

--- a/convert/src/LatexParser.hx
+++ b/convert/src/LatexParser.hx
@@ -138,6 +138,8 @@ class LatexParser extends Parser<LexerTokenSource<LatexToken>, LatexToken> imple
 				case [TCommand(CClearpage)]:
 				case [TCommand(CTableofcontents)]:
 				case [TCommand(CMaketitle)]:
+				case [TCommand(CNoindent)]:
+				case [TCommand(CMbox), TBrOpen, TBrClose]:
 				case [TCustomCommand("todototoc")]:
 				case [TCustomCommand("listoftodos")]:
 
@@ -288,6 +290,7 @@ class LatexParser extends Parser<LexerTokenSource<LatexToken>, LatexToken> imple
 				}
 			case [TCommand(CTextasciitilde)]: "~";
 			case [TCommand(CTextbackslash)]: "\\\\";
+			case [TCommand(CSlash)]: "/";
 			case [TCommand(CEmph), s = inBraces(text)]: '**$s**';
 			case [TCommand(CTextwidth)]: "";
 			case [TCommand(CTextsuperscript), s = inBraces(text)]:'<sup>$s</sup>';


### PR DESCRIPTION
Should fix #120.


@Simn, I had no idea of what I was doing! Please review my changes and make sure I didn't screw anything up.

Also, I couldn't figure out how to implement a generic `\mbox{}` that worked with empty contents

     case [TCommand(CMbox), s = inBraces(text)]

What was my mistake?


