### PR TITLE
RegExp flag `s` also applied to Flash

### DIFF
--- a/HaxeManual/10-std.tex
+++ b/HaxeManual/10-std.tex
@@ -182,7 +182,7 @@ The possible flags are the following:
 	\item \expr{i} case insensitive matching
 	\item \expr{g} global replace or split, see below
 	\item \expr{m} multiline matching, \expr{\textasciicircum} and \expr{\$} represent the beginning and end of a line
-	\item \expr{s} the dot \expr{.} will also match newlines \emph{(Neko, C++, PHP and Java targets only)}
+	\item \expr{s} the dot \expr{.} will also match newlines \emph{(Neko, C++, PHP, Flash and Java targets only)}
 	\item \expr{u} use UTF-8 matching \emph{(Neko and C++ targets only)}
 \end{itemize}
 


### PR DESCRIPTION
```haxe
class Main {	
	static function main() {
		var pat = ~/\{(.*)\}/s;
		var str = '{
			
			abc: 1,
			
			xyz: "adf",
			
			
			arr: ["a","b"]
		}
		';		
		trace(pat.match(str) ? pat.matched(1) : "false");
	}	
}
```

```bash
haxe -main Main -swf a.swf
```