### PR TITLE
Fix the spelling of JavaScript and ActionScript

### DIFF
--- a/HaxeManual/01-introduction.tex
+++ b/HaxeManual/01-introduction.tex
@@ -17,7 +17,7 @@ Currently, there are nine supported target languages which allow for different u
 \begin{tabular}{| l | l | l |}
 	\hline
 	Name & Output type & Main usages \\ \hline
-	Javascript & Sourcecode & Browser, Desktop, Mobile, Server \\
+	JavaScript & Sourcecode & Browser, Desktop, Mobile, Server \\
 	Neko & Bytecode & Desktop, Server \\
 	PHP & Sourcecode & Server \\
 	Python & Sourcecode & Desktop, Server \\
@@ -56,7 +56,7 @@ Source code looks like this:
 \begin{lstlisting}
 Haxe code here
 \end{lstlisting}
-Occasionally, we demonstrate how Haxe code is generated, for which we usually show the \target{Javascript} target.
+Occasionally, we demonstrate how Haxe code is generated, for which we usually show the \target{JavaScript} target.
 
 Furthermore, we define a set of terms in this document. Predominantly, this is done when introducing a new type or when a term is specific to Haxe. We do not define every new aspect we introduce, e.g. what a class is, to avoid cluttering the text. A definition looks like this:
 
@@ -110,13 +110,13 @@ The Haxe project was started on 22 October 2005 by French developer \emph{Nicola
 
 Being spelled \emph{haXe} back then, its beta version was released in February 2006 with the first supported targets being AVM\footnote{Adobe Virtual Machine}-bytecode and Nicolas' own \emph{Neko} virtual machine\footnote{http://nekovm.org}.
 
-Nicolas Cannasse, who remains leader of the Haxe project to this date, kept on designing Haxe with a clear vision, subsequently leading to the Haxe 1.0 release in May 2006. This first major release came with support for \target{Javascript} code generation and already had some of the features that define Haxe today such as type inference and structural sub-typing.
+Nicolas Cannasse, who remains leader of the Haxe project to this date, kept on designing Haxe with a clear vision, subsequently leading to the Haxe 1.0 release in May 2006. This first major release came with support for \target{JavaScript} code generation and already had some of the features that define Haxe today such as type inference and structural sub-typing.
 
 Haxe 1 saw several minor releases over the course of two years, adding the \target{Flash AVM2} target along with the \emph{haxelib}-tool in August 2006 and the \target{Actionscript 3} target in March 2007. During these months, there was a strong focus on improving stability, which resulted in several minor bug-fix releases.
 
 Haxe 2.0 was released in July 2008, including the \target{PHP} target, courtesy of \emph{Franco Ponticelli}. A similar effort by \emph{Hugh Sanderson} lead to the addition of the \target{C++} target in July 2009 with the Haxe 2.04 release.
 
-Just as with Haxe 1, what followed were several months of stability releases. In January 2011, Haxe 2.07 was released with the support of \emph{macros}. Around that time, \emph{Bruno Garcia} joined the team as maintainer of the \target{Javascript} target, which saw vast improvements in the subsequent 2.08 and 2.09 releases.
+Just as with Haxe 1, what followed were several months of stability releases. In January 2011, Haxe 2.07 was released with the support of \emph{macros}. Around that time, \emph{Bruno Garcia} joined the team as maintainer of the \target{JavaScript} target, which saw vast improvements in the subsequent 2.08 and 2.09 releases.
 
 After the release of 2.09, \emph{Simon Krajewski} joined the team and work towards Haxe 3 began. Furthermore, \emph{Cau\^{e} Waneck}'s \target{Java} and \target{C\#} targets found their way into the Haxe builds. It was then decided to make one final Haxe 2 release, which happened in July 2012 with the release of Haxe 2.10.
 

--- a/HaxeManual/01-introduction.tex
+++ b/HaxeManual/01-introduction.tex
@@ -22,7 +22,7 @@ Currently, there are nine supported target languages which allow for different u
 	PHP & Sourcecode & Server \\
 	Python & Sourcecode & Desktop, Server \\
 	C++ & Sourcecode & Desktop, Mobile, Server \\
-	Actionscript 3 & Sourcecode & Browser, Desktop, Mobile \\
+	ActionScript 3 & Sourcecode & Browser, Desktop, Mobile \\
 	Flash & Bytecode & Browser, Desktop, Mobile \\ 
 	Java & Sourcecode & Desktop, Server \\
 	C\# & Sourcecode & Desktop, Mobile, Server \\ \hline
@@ -112,7 +112,7 @@ Being spelled \emph{haXe} back then, its beta version was released in February 2
 
 Nicolas Cannasse, who remains leader of the Haxe project to this date, kept on designing Haxe with a clear vision, subsequently leading to the Haxe 1.0 release in May 2006. This first major release came with support for \target{JavaScript} code generation and already had some of the features that define Haxe today such as type inference and structural sub-typing.
 
-Haxe 1 saw several minor releases over the course of two years, adding the \target{Flash AVM2} target along with the \emph{haxelib}-tool in August 2006 and the \target{Actionscript 3} target in March 2007. During these months, there was a strong focus on improving stability, which resulted in several minor bug-fix releases.
+Haxe 1 saw several minor releases over the course of two years, adding the \target{Flash AVM2} target along with the \emph{haxelib}-tool in August 2006 and the \target{ActionScript 3} target in March 2007. During these months, there was a strong focus on improving stability, which resulted in several minor bug-fix releases.
 
 Haxe 2.0 was released in July 2008, including the \target{PHP} target, courtesy of \emph{Franco Ponticelli}. A similar effort by \emph{Hugh Sanderson} lead to the addition of the \target{C++} target in July 2009 with the Haxe 2.04 release.
 

--- a/HaxeManual/02-types.tex
+++ b/HaxeManual/02-types.tex
@@ -650,7 +650,7 @@ The syntax is reminiscent of classes and the semantics are indeed similar. In fa
 Furthermore, abstracts can be instantiated and used just like classes:
 
 \haxe[firstline=7,lastline=12]{assets/MyAbstract.hx}
-As mentioned before, abstracts are a compile-time feature, so it is interesting to see what the above actually generates. A suitable target for this is \target{Javascript}, which tends to generate concise and clean code. Compiling the above (using \texttt{haxe -main MyAbstract -js myabstract.js}) shows this \target{Javascript} code:
+As mentioned before, abstracts are a compile-time feature, so it is interesting to see what the above actually generates. A suitable target for this is \target{JavaScript}, which tends to generate concise and clean code. Compiling the above (using \texttt{haxe -main MyAbstract -js myabstract.js}) shows this \target{JavaScript} code:
 
 \begin{lstlisting}
 var a = 12;
@@ -691,7 +691,7 @@ Similarly, adding \expr{@:to} to a function qualifies it as implicit cast functi
 
 In the example the method \expr{fromString} allows the assignment of value \expr{"3"} to variable \expr{a} of type \type{MyAbstract} while the method \expr{toArray} allows assigning that abstract to variable \expr{b} of type \type{Array<Int>}.
 
-When using this kind of cast, calls to the cast-functions are inserted where required. This becomes obvious when looking at the \target{Javascript} output:
+When using this kind of cast, calls to the cast-functions are inserted where required. This becomes obvious when looking at the \target{JavaScript} output:
 
 \begin{lstlisting}
 var a = _ImplicitCastField.MyAbstract_Impl_.fromString("3");
@@ -731,7 +731,7 @@ While the individual casts from \type{A} to \type{B} and from \type{B} to \type{
 Abstracts allow overloading of unary and binary operators by adding the \expr{@:op} metadata to class fields:
 
 \haxe{assets/AbstractOperatorOverload.hx}
-By defining \expr{@:op(A * B)}, the function \expr{repeat} serves as operator method for the multiplication \expr{*} operator when the type of the left value is \type{MyAbstract} and the type of the right value is \type{Int}. The usage is shown in line 17, which turns into this when compiled to \target{Javascript}:
+By defining \expr{@:op(A * B)}, the function \expr{repeat} serves as operator method for the multiplication \expr{*} operator when the type of the left value is \type{MyAbstract} and the type of the right value is \type{Int}. The usage is shown in line 17, which turns into this when compiled to \target{JavaScript}:
 
 \begin{lstlisting}
 console.log(_AbstractOperatorOverload.
@@ -820,7 +820,7 @@ By adding the \expr{:enum} metadata to an abstract definition, that abstract can
 
 \haxe{assets/AbstractEnum.hx}
 
-The Haxe Compiler replaces all field access to the \type{HttpStatus} abstract with their values, as evident in the \target{Javascript} output:
+The Haxe Compiler replaces all field access to the \type{HttpStatus} abstract with their values, as evident in the \target{JavaScript} output:
 
 \begin{lstlisting}
 Main.main = function() {
@@ -856,7 +856,7 @@ When wrapping an underlying type, it is sometimes desirable to ``keep'' parts of
 
 The \type{MyArray} abstract in this example wraps \type{Array}. Its \expr{:forward} metadata has two arguments which correspond to the field names to be forwarded to the underlying type. In this example, the \expr{main} method instantiates \type{MyArray} and accesses its \expr{push} and \expr{pop} methods. The commented line demonstrates that the \expr{length} field is not available.
 
-As usual we can look at the \target{Javascript} output to see how the code is being generated:
+As usual we can look at the \target{JavaScript} output to see how the code is being generated:
 
 \begin{lstlisting}
 Main.main = function() {

--- a/HaxeManual/03-type-system.tex
+++ b/HaxeManual/03-type-system.tex
@@ -117,7 +117,7 @@ A class or function can be made \emph{generic} by attributing it with the \expr{
 
 \haxe{assets/GenericClass.hx}
 
-It seems unusual to see the explicit type \type{MyArray<String>} here as we usually let \tref{type inference}{type-system-type-inference} deal with this. Nonetheless, it is indeed required in this case. The compiler has to know the exact type of a generic class upon construction. The \target{Javascript} output shows the result:
+It seems unusual to see the explicit type \type{MyArray<String>} here as we usually let \tref{type inference}{type-system-type-inference} deal with this. Nonetheless, it is indeed required in this case. The compiler has to know the exact type of a generic class upon construction. The \target{JavaScript} output shows the result:
 
 \begin{lstlisting}
 (function () { "use strict";
@@ -140,7 +140,7 @@ We can identify that \type{MyArray<String>} and \type{MyArray<Int>} have become 
 
 \haxe{assets/GenericFunction.hx}
 
-Again, the \target{Javascript} output makes it obvious:
+Again, the \target{JavaScript} output makes it obvious:
 
 \begin{lstlisting}
 (function () { "use strict";
@@ -174,7 +174,7 @@ It should be noted that \tref{top-down inference}{type-system-top-down-inference
 	\item be explicitly \tref{constrained}{type-system-type-parameter-constraints} to having a \tref{constructor}{types-class-constructor}.
 \end{enumerate}
 
-Here, 1. is given by \expr{make} having the \expr{@:generic} metadata, and 2. by \type{T} being constrained to \type{Constructible}. The constraint holds for both \type{String} and \type{haxe.Template} as both have a constructor accepting a singular \type{String} argument. Sure enough, the relevant \target{Javascript} output looks as expected:
+Here, 1. is given by \expr{make} having the \expr{@:generic} metadata, and 2. by \type{T} being constrained to \type{Constructible}. The constraint holds for both \type{String} and \type{haxe.Template} as both have a constructor accepting a singular \type{String} argument. Sure enough, the relevant \target{JavaScript} output looks as expected:
 
 \begin{lstlisting}
 var Main = function() { }

--- a/HaxeManual/04-class-field.tex
+++ b/HaxeManual/04-class-field.tex
@@ -92,7 +92,7 @@ The next example shows common access identifier combinations for properties:
 
 \haxe{assets/Property2.hx}
 
-The \target{Javascript} output helps understand what the field access in the \expr{main}-method is compiled to:
+The \target{JavaScript} output helps understand what the field access in the \expr{main}-method is compiled to:
 
 \begin{lstlisting}
 var Main = function() {
@@ -260,7 +260,7 @@ The \expr{inline} keyword allows function bodies to be directly inserted in plac
 
 \haxe{assets/Inline.hx}
 
-The generated \target{Javascript} output reveals the effect of inline:
+The generated \target{JavaScript} output reveals the effect of inline:
 
 \begin{lstlisting}
 (function () { "use strict";

--- a/HaxeManual/06-language-features.tex
+++ b/HaxeManual/06-language-features.tex
@@ -316,7 +316,7 @@ We see that externs can define both methods and variables (actually, \expr{PI} i
 
 This works because the return type of method \expr{floor} is declared to be \type{Int}.
 
-The Haxe Standard Library comes with many externs for the \target{Flash} and \target{Javascript} target. They allow accessing the native APIs in a type-safe manner and are instrumental for designing higher-level APIs. There are also externs for many popular native libraries on \tref{haxelib}{haxelib}.
+The Haxe Standard Library comes with many externs for the \target{Flash} and \target{JavaScript} target. They allow accessing the native APIs in a type-safe manner and are instrumental for designing higher-level APIs. There are also externs for many popular native libraries on \tref{haxelib}{haxelib}.
 
 The \target{Flash}, \target{Java} and \target{C\#} targets allow direct inclusion of native libraries from \tref{command line}{compiler-usage}. Target-specific details are explained in the respective sections of \Fullref{target-details}.
 
@@ -365,7 +365,7 @@ Several classes in the Haxe Standard Library are suitable for static extension u
 
 \haxe{assets/StaticExtension2.hx}
 
-While \type{String} does not have a \expr{replace} functionality by itself, the \expr{using StringTools} static extension provides one. As usual, the \target{Javascript} output nicely shows the transformation:
+While \type{String} does not have a \expr{replace} functionality by itself, the \expr{using StringTools} static extension provides one. As usual, the \target{JavaScript} output nicely shows the transformation:
 
 \begin{lstlisting}
 Main.main = function() {
@@ -780,7 +780,7 @@ The following example demonstrates constructor inlining:
 
 \haxe{assets/NewInline.hx}
 
-A look at the \target{Javascript} output reveals the effect:
+A look at the \target{JavaScript} output reveals the effect:
 
 \begin{lstlisting}
 Main.main = function() {

--- a/HaxeManual/07-compiler-usage.tex
+++ b/HaxeManual/07-compiler-usage.tex
@@ -28,7 +28,7 @@ The second question usually comes down to providing an argument specifying the d
 
 \begin{description}
 	\item[\ic{-js file_name}] Generates \tref{JavaScript}{target-javascript} source code in specified file.
-	\item[\ic{-as3 directory}] Generates Actionscript 3 source code in specified directory.
+	\item[\ic{-as3 directory}] Generates ActionScript 3 source code in specified directory.
 	\item[\ic{-swf file_name}] Generates the specified file as \tref{Flash}{target-flash} .swf.
 	\item[\ic{-neko file_name}] Generates \tref{Neko}{target-neko} binary as specified file.
 	\item[\ic{-php directory}] Generates \tref{PHP}{target-php} source code in specified directory.

--- a/HaxeManual/07-compiler-usage.tex
+++ b/HaxeManual/07-compiler-usage.tex
@@ -12,7 +12,7 @@ The Haxe Compiler is typically invoked from command line with several arguments 
 	
 To answer the first question, it is usually sufficient to provide a class path via the \ic{-cp path} argument, along with the main class to be compiled via the \ic{-main dot_path} argument. The Haxe Compiler then resolves the main class file and begins compilation.
 
-The second question usually comes down to providing an argument specifying the desired target. Each Haxe target has a dedicated command line switch, such as \ic{-js file_name} for Javascript and \ic{-php directory} for PHP. Depending on the nature of the target, the argument value is either a file name (for \ic{-js}, \ic{-swf} and \ic{neko}) or a directory path.
+The second question usually comes down to providing an argument specifying the desired target. Each Haxe target has a dedicated command line switch, such as \ic{-js file_name} for JavaScript and \ic{-php directory} for PHP. Depending on the nature of the target, the argument value is either a file name (for \ic{-js}, \ic{-swf} and \ic{neko}) or a directory path.
 
 \paragraph{Common arguments}
 
@@ -27,7 +27,7 @@ The second question usually comes down to providing an argument specifying the d
 \emph{Output:}
 
 \begin{description}
-	\item[\ic{-js file_name}] Generates \tref{Javascript}{target-javascript} source code in specified file.
+	\item[\ic{-js file_name}] Generates \tref{JavaScript}{target-javascript} source code in specified file.
 	\item[\ic{-as3 directory}] Generates Actionscript 3 source code in specified directory.
 	\item[\ic{-swf file_name}] Generates the specified file as \tref{Flash}{target-flash} .swf.
 	\item[\ic{-neko file_name}] Generates \tref{Neko}{target-neko} binary as specified file.

--- a/HaxeManual/08-compiler-features.tex
+++ b/HaxeManual/08-compiler-features.tex
@@ -43,7 +43,7 @@ Starting from Haxe 3.0, you can get the list of defined compiler metadata by run
 	@:deprecated   &  Automatically added by \expr{-java-lib} on class fields annotated with \expr{@Deprecated} annotation. Has no effect on types compiled by Haxe  &  java \\
 	@:event  &  Automatically added by \expr{-net-lib} on events. Has no effect on types compiled by Haxe   &  cs \\
 	@:enum  &  Defines finite value sets to abstract definitions. See \tref{enum abstracts}{types-abstract-enum}  &  all \\
-	@:expose \_(?Name=Class path)\_  &  Makes the class available on the \expr{window} object or \expr{exports} for node.js. See \tref{exposing Haxe classes for Javascript}{target-javascript-expose} &  js \\
+	@:expose \_(?Name=Class path)\_  &  Makes the class available on the \expr{window} object or \expr{exports} for node.js. See \tref{exposing Haxe classes for JavaScript}{target-javascript-expose} &  js \\
 	@:extern  &  Marks the field as extern so it is not generated  &  all \\
 	@:fakeEnum \_(Type name)\_  &  Treat enum as collection of values of the specified type  &  all \\
 	@:file(File path)  &  Includes a given binary file into the target Swf and associates it with the class (must extend \expr{flash.utils.ByteArray})  &  flash \\
@@ -152,7 +152,7 @@ The compiler automatically defines the flag \expr{dce} with a value of either \e
 
 \trivia{DCE-rewrite}{DCE was originally implemented in Haxe 2.07. This implementation considered a function to be used when it was explicitly typed. The problem with that was that several features, most importantly interfaces, would cause all class fields to be typed in order to verify type-safety. This effectively subverted DCE completely, prompting the rewrite for Haxe 2.10.}
 
-\trivia{DCE and try.haxe.org}{DCE for the \type{Javascript} target saw vast improvements when the website \url{http://try.haxe.org} was published. Initial reception of the generated \target{Javascript} code was mixed, leading to a more fine-grained selection of which code to eliminate.}
+\trivia{DCE and try.haxe.org}{DCE for the \type{JavaScript} target saw vast improvements when the website \url{http://try.haxe.org} was published. Initial reception of the generated \target{JavaScript} code was mixed, leading to a more fine-grained selection of which code to eliminate.}
 
 
 

--- a/HaxeManual/10-std.tex
+++ b/HaxeManual/10-std.tex
@@ -42,7 +42,7 @@ Arrays define an \tref{iterator}{lf-iterators} over their elements. This iterati
 
 \haxe{assets/ArrayIterator.hx}
 
-Haxe generates this optimized \target{Javascript} output:
+Haxe generates this optimized \target{JavaScript} output:
 
 \begin{lstlisting}
 Main.main = function() {
@@ -671,7 +671,7 @@ There are some target-specific constructors with different purposes that can be 
 				Allows remoting communications over a \href{http://api.haxe.org/haxe/remoting/LocalConnection.html}{Flash LocalConnection}
 		\end{description}
 		
-	\item[Javascript:]
+	\item[JavaScript:]
 		\begin{description}
 			\item[\expr{ExternalConnection.flashConnect(name:String, obj:String, ctx:Context)}]  
 				Allows a connection to a given Flash Object. The Haxe Flash content must be loaded and it must include the \expr{haxe.remoting.Connection} class. This only works with Flash 8 and higher. 
@@ -743,7 +743,7 @@ Haxe Remoting can send a lot of different kinds of data. See \tref{Serialization
 \subsection{Implementation details}
 \label{std-remoting-implementation-details}
 
-\paragraph{Javascript security specifics}
+\paragraph{JavaScript security specifics}
 
 The html-page wrapping the js client must be served from the same domain as the one where the server is running. The same-origin policy restricts how a document or script loaded from one origin can interact with a resource from another origin. The same-origin policy is used as a means to prevent some of the cross-site request forgery attacks.
 

--- a/HaxeManual/12-target-details.tex
+++ b/HaxeManual/12-target-details.tex
@@ -2,14 +2,14 @@
 \label{target-details}
 \state{NoContent}
 
-\section{Javascript}
+\section{JavaScript}
 \label{target-javascript}
 \state{NoContent}
 
-\subsection{Getting started with Haxe/Javascript}
+\subsection{Getting started with Haxe/JavaScript}
 \label{target-javascript-getting-started}
 
-Haxe can be a powerful tool for developing Javascript applications. Let's look at our first sample.
+Haxe can be a powerful tool for developing JavaScript applications. Let's look at our first sample.
 This is a very simple example showing the toolchain. 
 
 Create a new folder and save this class as \ic{Main.hx}.
@@ -46,7 +46,7 @@ Another possibility is to create and run (double-click) a file called \ic{compil
 
 The output will be a main-javascript.js, which creates and adds a clickable button to the document body.
 
-\paragraph{Run the Javascript}
+\paragraph{Run the JavaScript}
 
 To display the output in a browser, create an HTML-document called \ic{index.html} and open it.
 
@@ -62,14 +62,14 @@ To display the output in a browser, create an HTML-document called \ic{index.htm
 \paragraph{More information}
 
 \begin{itemize}
-	\item \href{http://api.haxe.org/js/}{Haxe Javascript API docs}
+	\item \href{http://api.haxe.org/js/}{Haxe JavaScript API docs}
 	\item \href{https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference}{MDN JavaScript Reference}
 \end{itemize}
 
-\subsection{Using external Javascript libraries}
+\subsection{Using external JavaScript libraries}
 \label{target-javascript-external-libraries}
 
-The Haxe Standard Library comes with many externs for the Javascript target. They provide access to the native APIs in a type-safe manner.
+The Haxe Standard Library comes with many externs for the JavaScript target. They provide access to the native APIs in a type-safe manner.
 The \tref{externs mechanism}{lf-externs} assumes that the defined types exist at run-time but assumes nothing about how and where those types are defined. 
 To clarify, in most cases we have to add a \ic{<script>}-tag that links the external library manually to the HTML-document.
 
@@ -97,7 +97,7 @@ Using this extern, we can use jQuery like this:
 new JQuery("#my-div").addClass("brand-success").html("haxe is great!");
 \end{lstlisting}
 
-Beside externs, \tref{Typedefs}{type-system-typedef} can be another great way to name (or alias) complex Javascript or JSON structures.
+Beside externs, \tref{Typedefs}{type-system-typedef} can be another great way to name (or alias) complex JavaScript or JSON structures.
 
 The package and class name of the extern class should be the same as defined in the external library. If that is not the case, rewrite the path of a class using \expr{@:native}.
 
@@ -115,8 +115,8 @@ In Haxe, it is possible to call an exposed function thanks to the \expr{untyped}
 untyped window.trackEvent("page1");  
 \end{lstlisting}
 
-Using the magic \expr{__js__} function we can inject pure Javascript code fragments into the output. This code can not be validated, so it accepts invalid code in the output, which is error-prone.
-This could, for example, write a Javascript comment in the output.
+Using the magic \expr{__js__} function we can inject pure JavaScript code fragments into the output. This code can not be validated, so it accepts invalid code in the output, which is error-prone.
+This could, for example, write a JavaScript comment in the output.
 
 \begin{lstlisting}
 untyped __js__('// haxe is great!');
@@ -130,15 +130,15 @@ The standard compilation options also provide more Haxe sources to be added to t
 	\item To force a whole package to be included in the project, use \expr{--macro include('mypackage')} which will include all the classes declared in the given package and subpackages. 
 \end{itemize}
 
-\subsection{Javascript target Metadata}
+\subsection{JavaScript target Metadata}
 \label{target-javascript-metadata}
 
-This is the list of Javascript specific metadata. For more information, see also the complete list of all \tref{Haxe built-in metadata}{cr-metadata}.
+This is the list of JavaScript specific metadata. For more information, see also the complete list of all \tref{Haxe built-in metadata}{cr-metadata}.
 
 \begin{center}
 \begin{tabular}{| l | l |}
 	\hline
-	\multicolumn{2}{|c|}{Javascript metadata} \\ \hline
+	\multicolumn{2}{|c|}{JavaScript metadata} \\ \hline
 	Metadata &  Description \\ \hline
 	@:expose \_(?Name=Class path)\_  &  Makes the class available on the \expr{window} object or \expr{exports} for node.js  \\
 	@:jsRequire  &  Generate javascript module require expression for given extern \\
@@ -146,17 +146,17 @@ This is the list of Javascript specific metadata. For more information, see also
 \end{tabular}
 \end{center}
 
-\subsection{Exposing Haxe classes for Javascript}
+\subsection{Exposing Haxe classes for JavaScript}
 \label{target-javascript-expose}
 
-It is possible to make Haxe classes or static fields available for usage in plain Javascript. 
+It is possible to make Haxe classes or static fields available for usage in plain JavaScript. 
 To expose, add the \expr{@:expose} metadata to the desired class or static fields.
 
 This example exposes the Haxe class \ic{MyClass}.
 
 \haxe{assets/ClassExpose.hx}
 
-It generates the following Javascript output:
+It generates the following JavaScript output:
 
 \begin{lstlisting}
 (function ($hx_exports) { "use strict";
@@ -171,12 +171,12 @@ MyClass.prototype = {
 })(typeof window != "undefined" ? window : exports);
 \end{lstlisting}
 
-By passing globals (like \ic{window} or \ic{exports}) as parameters to our anonymous function in the Javascript module, it becomes available which allows to expose the Haxe generated module.
+By passing globals (like \ic{window} or \ic{exports}) as parameters to our anonymous function in the JavaScript module, it becomes available which allows to expose the Haxe generated module.
 
-In plain Javascript it is now possible to create an instance of the class and call its public functions.
+In plain JavaScript it is now possible to create an instance of the class and call its public functions.
 
 \begin{lstlisting}
-// Javascript code
+// JavaScript code
 var instance = new MyClass('Mark');
 console.log(instance.foo()); // logs a message in the console
 \end{lstlisting}
@@ -185,7 +185,7 @@ The package path of the Haxe class will be completely exposed. To rename the cla
 
 \paragraph{Shallow expose}
 
-When the code generated by Haxe is part of a larger Javascript project and wrapped in a large closure it is not always necessary to expose the Haxe types to global variables.
+When the code generated by Haxe is part of a larger JavaScript project and wrapped in a large closure it is not always necessary to expose the Haxe types to global variables.
 Compiling the project using \ic{-D shallow-expose} allows the types or static fields to be available for the surrounding scope of the generated closure only.
 
 When the code is compiled using \ic{-D shallow-expose}, the generated output will look like this:

--- a/HaxeManual/12-target-details.tex
+++ b/HaxeManual/12-target-details.tex
@@ -300,7 +300,7 @@ To display the output in a browser using the Flash-plugin, create an HTML-docume
 \subsection{Embedding resources}
 \label{target-flash-resources}
 
-Embedding resources is different in Haxe compared to Actionscript 3. Instead of using \ic{\[embed\]} (AS3-metadata) use \tref{Flash specific compiler metadata}{target-flash-metadata} like \ic{@:bitmap}, \ic{@:font}, \ic{@:sound} or \ic{@:file}.
+Embedding resources is different in Haxe compared to ActionScript 3. Instead of using \ic{\[embed\]} (AS3-metadata) use \tref{Flash specific compiler metadata}{target-flash-metadata} like \ic{@:bitmap}, \ic{@:font}, \ic{@:sound} or \ic{@:file}.
 
 \begin{lstlisting}
 import flash.Lib;

--- a/HaxeManual/todo.txt
+++ b/HaxeManual/todo.txt
@@ -240,10 +240,10 @@ Unreviewed:
 11.2.2 - Dependencies
 11.3 - extraParams.hxml
 11.4 - Using Haxelib
-12.1.1 - Getting started with Haxe/Javascript
-12.1.2 - Using external Javascript libraries
-12.1.3 - Javascript target Metadata
-12.1.4 - Exposing Haxe classes for Javascript
+12.1.1 - Getting started with Haxe/JavaScript
+12.1.2 - Using external JavaScript libraries
+12.1.3 - JavaScript target Metadata
+12.1.4 - Exposing Haxe classes for JavaScript
 12.1.5 - Loading extern classes using "require" function
 12.2.1 - Getting started with Haxe/Flash
 12.2.2 - Embedding resources


### PR DESCRIPTION
Script should be capitalized.