### PR TITLE
Compile the HaxeManual code examples on Travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ toc.sv
 output/HaxeManual/ebook/content.md
 output/HaxeManual/ebook/dictionary.md
 output/HaxeManual/ebook/sections.txt
+HaxeManual/assets/bin/
+tests/RunTravis.n

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,18 @@ haxe:
   
 env: 
   - TARGET=swf
+  - TARGET=as3
   - TARGET=js
   - TARGET=neko
   - TARGET=cpp
+  - TARGET=cs
+  - TARGET=java
+  - TARGET=python
 
 install:
   - haxelib install hxcpp > /dev/null
+  - haxelib install hxcs > /dev/null
+  - haxelib install hxjava > /dev/null
   - haxelib install random > /dev/null
   - haxelib list
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: haxe
 
 haxe:
   - "3.2.0"
-  - "3.1.3"
   - development
   
 env: 

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ env:
   - TARGET=python
 
 install:
+  - sudo apt-get install mono-devel mono-mcs -qq
   - haxelib install hxcpp > /dev/null
   - haxelib install hxcs > /dev/null
   - haxelib install hxjava > /dev/null

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,4 @@ install:
 script:
   - cd ./tests
   - haxe RunTravis.hxml
-  - neko RunTravis.n
+  - neko RunTravis.n $TARGET

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: haxe
+
+haxe:
+  - "3.2.0"
+  - "3.1.3"
+  - development
+  
+env: 
+  - TARGET=swf
+  - TARGET=js
+  - TARGET=neko
+  - TARGET=cpp
+
+install:
+  - haxelib install hxcpp > /dev/null
+
+script:
+  - cd ./tests
+  - haxe RunTravis.hxml
+  - neko RunTravis.n

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ env:
 
 install:
   - haxelib install hxcpp > /dev/null
+  - haxelib install random > /dev/null
+  - haxelib list
 
 script:
   - cd ./tests

--- a/HaxeManual/09-macros.tex
+++ b/HaxeManual/09-macros.tex
@@ -252,6 +252,8 @@ Normal \tref{build-macros}{macro-type-building} are run per-type and are already
 
 \expr{@:genericBuild} is used just like \expr{@:build} by adding it to a type with the argument being a macro call:
 
+\haxe{assets/GenericBuildMacro1.hx}
+
 \haxe{assets/GenericBuild1.hx}
 
 When running this example the compiler outputs \ic{TAbstract(Int,[])} and \ic{TInst(String,[])}, indicating that it is indeed aware of the concrete type parameters of \type{MyType}. The macro logic could use this information to generate a custom type (using \expr{haxe.macro.Context.defineType}) or refer to an existing one. For brevity we return \expr{null} here which asks the compiler to \tref{infer}{type-system-type-inference} the type.
@@ -261,6 +263,8 @@ In Haxe 3.1 the return type of a \expr{@:genericBuild} macro has to be a \type{h
 \paragraph{Const type parameter}
 
 Haxe allows passing \tref{constant expression}{expression-constants} as a type parameter if the type parameter name is \expr{Const}. This can be utilized in the context of \expr{@:genericBuild} macros to pass information from the syntax directly to the macro:
+
+\haxe{assets/GenericBuildMacro2.hx}
 
 \haxe{assets/GenericBuild2.hx}
 

--- a/HaxeManual/assets/AbstractOperatorOverload.hx
+++ b/HaxeManual/assets/AbstractOperatorOverload.hx
@@ -12,7 +12,7 @@ abstract MyAbstract(String) {
   }
 }
 
-class AbstractOperatorOverload {
+class Main {
   static public function main() {
     var a = new MyAbstract("foo");
     trace(a * 3); // foofoofoo

--- a/HaxeManual/assets/AbstractUnopOverload.hx
+++ b/HaxeManual/assets/AbstractUnopOverload.hx
@@ -9,7 +9,7 @@ abstract MyAbstract(String) {
     return this + "post";
 }
 
-class AbstractUnopOverload {
+class Main {
   static public function main() {
     var a = new MyAbstract("foo");
     trace(++a); // prefoo

--- a/HaxeManual/assets/AdvArrayComprehension.hx
+++ b/HaxeManual/assets/AdvArrayComprehension.hx
@@ -1,4 +1,4 @@
-class AdvArrayComprehension {
+class Main {
   static public function main() {
     var a = [
       for (a in 1...11)

--- a/HaxeManual/assets/Bind.hx
+++ b/HaxeManual/assets/Bind.hx
@@ -1,4 +1,4 @@
-class Bind {
+class Main {
   static public function main() {
     var map = new Map<Int,String>();
     var f = map.set.bind(_, "12");

--- a/HaxeManual/assets/ConditionalCompilation.hx
+++ b/HaxeManual/assets/ConditionalCompilation.hx
@@ -1,4 +1,4 @@
-class ConditionalCompilation {
+class Main {
   public static function main(){
     #if !debug
       trace("ok");

--- a/HaxeManual/assets/Constraints.hx
+++ b/HaxeManual/assets/Constraints.hx
@@ -2,7 +2,7 @@ typedef Measurable = {
   public var length(default, null):Int;
 }
 
-class Constraints {
+class Main {
   static public function main() {
     trace(test([]));
     trace(test(["bar", "foo"]));

--- a/HaxeManual/assets/DefaultValues.hx
+++ b/HaxeManual/assets/DefaultValues.hx
@@ -8,7 +8,7 @@ class Main {
     trace(test("foo")); // i: 12, s: foo
   }
 
-  static function test(i = 12, s = "bar") {
+  static function test(?i = 12, s = "bar") {
     return "i: " +i + ", s: " +s;
   }
 }

--- a/HaxeManual/assets/DefaultValues.hx
+++ b/HaxeManual/assets/DefaultValues.hx
@@ -1,4 +1,4 @@
-class DefaultValues {
+class Main {
   static public function main() {
     // ?i : Int -> ?s : String -> String
     $type(test);

--- a/HaxeManual/assets/Extension.hx
+++ b/HaxeManual/assets/Extension.hx
@@ -4,7 +4,7 @@ typedef IterableWithLength<T> = {
   var length(default, null):Int;
 }
 
-class Extension {
+class Main {
   static public function main() {
     var array = [1, 2, 3];
     var t:IterableWithLength<Int> = array;

--- a/HaxeManual/assets/Extension2.hx
+++ b/HaxeManual/assets/Extension2.hx
@@ -8,7 +8,7 @@ typedef IterableWithLengthAndPush<T> = {
   function push(a:T):Int;
 }
 
-class Extension2 {
+class Main {
   static public function main() {
     var array = [1, 2, 3];
     var t:IterableWithLengthAndPush<Int> = array;

--- a/HaxeManual/assets/FunctionType.hx
+++ b/HaxeManual/assets/FunctionType.hx
@@ -1,4 +1,4 @@
-class FunctionType {
+class Main {
   static public function main() {
     // i : Int -> s : String -> Bool
     $type(test);

--- a/HaxeManual/assets/GenericBuild1.hx
+++ b/HaxeManual/assets/GenericBuild1.hx
@@ -1,22 +1,4 @@
-// MyMacro.hx
-import haxe.macro.Expr;
-import haxe.macro.Context;
-import haxe.macro.Type;
-
-class MyMacro {
-  static public function build() {
-    switch (Context.getLocalType()) {
-      case TInst(_, [t1]):
-        trace(t1);
-      case t:
-        Context.error("Class expected", Context.currentPos());
-    }
-    return null;
-  }
-}
-
-// Main.hx
-@:genericBuild(MyMacro.build())
+@:genericBuild(GenericBuildMacro1.build())
 class MyType<T> { }
 
 class Main {

--- a/HaxeManual/assets/GenericBuild2.hx
+++ b/HaxeManual/assets/GenericBuild2.hx
@@ -1,21 +1,4 @@
-import haxe.macro.Expr;
-import haxe.macro.Context;
-import haxe.macro.Type;
-
-class MyMacro {
-  static public function build() {
-    switch (Context.getLocalType()) {
-      case TInst(_,[TInst(_.get() => { kind: KExpr(macro $v{(s:String)}) },_)]):
-        trace(s);
-      case t:
-        Context.error("Class expected", Context.currentPos());
-    }
-    return null;
-  }
-}
-
-// Main.hx
-@:genericBuild(MyMacro.build())
+@:genericBuild(GenericBuildMacro2.build())
 class MyType<Const> { }
 
 class Main {

--- a/HaxeManual/assets/GenericBuildMacro1.hx
+++ b/HaxeManual/assets/GenericBuildMacro1.hx
@@ -1,0 +1,15 @@
+import haxe.macro.Expr;
+import haxe.macro.Context;
+import haxe.macro.Type;
+
+class GenericBuildMacro1 {
+  static public function build() {
+    switch (Context.getLocalType()) {
+      case TInst(_, [t1]):
+        trace(t1);
+      case t:
+        Context.error("Class expected", Context.currentPos());
+    }
+    return null;
+  }
+}

--- a/HaxeManual/assets/GenericBuildMacro2.hx
+++ b/HaxeManual/assets/GenericBuildMacro2.hx
@@ -1,0 +1,15 @@
+import haxe.macro.Expr;
+import haxe.macro.Context;
+import haxe.macro.Type;
+
+class GenericBuildMacro2 {
+  static public function build() {
+    switch (Context.getLocalType()) {
+      case TInst(_,[TInst(_.get() => { kind: KExpr(macro $v{(s:String)}) },_)]):
+        trace(s);
+      case t:
+        Context.error("Class expected", Context.currentPos());
+    }
+    return null;
+  }
+}

--- a/HaxeManual/assets/GenericClass.hx
+++ b/HaxeManual/assets/GenericClass.hx
@@ -1,7 +1,7 @@
 @:generic
 class MyValue<T> {
   public var value:T;
-    public function new(value:T) {
+  public function new(value:T) {
     this.value = value;
   }
 }

--- a/HaxeManual/assets/GenericStackExample.hx
+++ b/HaxeManual/assets/GenericStackExample.hx
@@ -1,6 +1,6 @@
 import haxe.ds.GenericStack;
 
-class GenericStackExample {
+class Main {
   static public function main() {
     var myStack = new GenericStack<Int>();
     for (ii in 0...5)

--- a/HaxeManual/assets/HelloWorld.hx
+++ b/HaxeManual/assets/HelloWorld.hx
@@ -1,4 +1,4 @@
-class HelloWorld {
+class Main {
   static public function main():Void {
     trace("Hello World");
   }

--- a/HaxeManual/assets/ImplicitCastDirect.hx
+++ b/HaxeManual/assets/ImplicitCastDirect.hx
@@ -4,7 +4,7 @@ abstract MyAbstract(Int) from Int to Int {
   }
 }
 
-class ImplicitCastDirect {
+class Main {
   static public function main() {
     var a:MyAbstract = 12;
     var b:Int = a;

--- a/HaxeManual/assets/ImplicitCastField.hx
+++ b/HaxeManual/assets/ImplicitCastField.hx
@@ -14,7 +14,7 @@ abstract MyAbstract(Int) {
   }
 }
 
-class ImplicitCastField {
+class Main {
   static public function main() {
     var a:MyAbstract = "3";
     var b:Array<Int> = a;

--- a/HaxeManual/assets/InlineRelying.hx
+++ b/HaxeManual/assets/InlineRelying.hx
@@ -9,7 +9,7 @@ class Main {
     }
   }
 
-  static inline function error(s:String) {
+  @:extern static inline function error(s:String) {
     throw s;
   }
 }

--- a/HaxeManual/assets/ListExample.hx
+++ b/HaxeManual/assets/ListExample.hx
@@ -1,4 +1,4 @@
-class ListExample {
+class Main {
   static public function main() {
     var myList = new List<Int>();
     for (ii in 0...5)

--- a/HaxeManual/assets/MathExample.hx
+++ b/HaxeManual/assets/MathExample.hx
@@ -1,4 +1,4 @@
-class MathExample {
+class Main {
   static public function main() {
     var x = 1/2;
     var y = 20.2;

--- a/HaxeManual/assets/MathExtensionUsage.hx
+++ b/HaxeManual/assets/MathExtensionUsage.hx
@@ -1,7 +1,7 @@
 using MathStaticExtension;
 
-class TestMath{
-  public static function main(){
+class Main {
+  public static function main() {
     var ang = 1/2*Math.PI;
     trace(ang.toDegrees()); //90
   }

--- a/HaxeManual/assets/MyAbstract.hx
+++ b/HaxeManual/assets/MyAbstract.hx
@@ -4,7 +4,7 @@ abstract AbstractInt(Int) {
   }
 }
 
-class MyAbstract {
+class Main {
   static public function main() {
     var a = new AbstractInt(12);
     trace(a); //12

--- a/HaxeManual/assets/OptionalArguments.hx
+++ b/HaxeManual/assets/OptionalArguments.hx
@@ -1,4 +1,4 @@
-class OptionalArguments {
+class Main {
   static public function main() {
     // ?i : Int -> ?s : String -> String
     $type(test);

--- a/HaxeManual/assets/SafeCast.hx
+++ b/HaxeManual/assets/SafeCast.hx
@@ -7,7 +7,7 @@ class Child1 extends Base {}
 class Child2 extends Base {}
 
 class Main {
-    public static function main() {
+  public static function main() {
     var child1:Base = new Child1();
     var child2:Base = new Child2();
     cast(child1, Base);

--- a/HaxeManual/assets/SelectiveFunction.hx
+++ b/HaxeManual/assets/SelectiveFunction.hx
@@ -8,7 +8,7 @@ abstract MyAbstract<T>(T) from T {
   }
 }
 
-class SelectiveFunction {
+class Main {
   static public function main() {
     var a = new MyAbstract("foo");
     a.getString();

--- a/HaxeManual/assets/Structure.hx
+++ b/HaxeManual/assets/Structure.hx
@@ -1,4 +1,4 @@
-class Structure {
+class Main {
   static public function main() {
     var myStructure = { x: 12, name: "foo"};
   }

--- a/HaxeManual/assets/Test.hx
+++ b/HaxeManual/assets/Test.hx
@@ -1,6 +1,7 @@
 class Test {
   static public function main() {
-    var point = { x: 0.0, y: 12.0};
+    var point = { x: 0.0, y: 12.0 };
+	// { y : Float, x : Float } has no field z
     point.z;
   }
 }

--- a/HaxeManual/assets/TypeInference.hx
+++ b/HaxeManual/assets/TypeInference.hx
@@ -1,4 +1,4 @@
-class TypeInference {
+class Main {
   public static function main() {
     var x = null;
     $type(x); // Unknown<0>

--- a/HaxeManual/assets/TypeInference2.hx
+++ b/HaxeManual/assets/TypeInference2.hx
@@ -1,4 +1,4 @@
-class TypeInference2 {
+class Main {
   public static function main() {
     var x = [];
     $type(x); // Array<Unknown<0>>

--- a/HaxeManual/assets/UnifyMin.hx
+++ b/HaxeManual/assets/UnifyMin.hx
@@ -5,7 +5,7 @@ class Base {
 class Child1 extends Base { }
 class Child2 extends Base { }
 
-class UnifyMin {
+class Main {
   static public function main() {
     var a = [new Child1(), new Child2()];
     $type(a); // Array<Base>

--- a/HaxeManual/assets/VariableField.hx
+++ b/HaxeManual/assets/VariableField.hx
@@ -1,4 +1,4 @@
-class VariableField {
+class Main {
   static var member:String = "bar";
 
   public static function main() {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 HaxeManual
 ==========
 
+[![Build Status](https://travis-ci.org/HaxeFoundation/HaxeManual.png)](https://travis-ci.org/HaxeFoundation/HaxeManual)
+
 For contributions please edit the .tex file.  The .md files are generated from it.
 
 To rebuild the .pdf from the command line, run `latexmk -xelatex HaxeDoc.tex`.

--- a/tests/RunTravis.hx
+++ b/tests/RunTravis.hx
@@ -44,7 +44,6 @@ class RunTravis
 		"Color.hx",
 		"ClassExpose.hx", // no main
 		"FunctionTypeParameter.hx",
-		"HaxelibRandom.hx", // needs a haxelib
 		"HelloPHP.hx", // PHP only
 		"ImplicitTransitiveCast.hx",
 		"JSRequireModule.hx",
@@ -73,6 +72,10 @@ class RunTravis
 		"EnumBuildingMacro.hx",
 		"MathStaticExtension.hx",
 		"TypeBuildingMacro.hx"
+	];
+	
+	static var haxelibs = [
+		"HaxelibRandom.hx" => ["random"]
 	];
 	
 	public static function main():Void {
@@ -114,12 +117,24 @@ class RunTravis
 	
 	static function hasExpectedResult(file:String, target:Target):ExitCode {
 		var expectedResult:ExitCode = requiredFailures.indexOf(file) == -1;
-		var compileResult = Sys.command("haxe", ["-main", "Main", '-$target', target]);
+		var compileResult = Sys.command("haxe", getCompileArgs(file, target));
 		
 		var result:ExitCode = compileResult == expectedResult;
 		if (result == ExitCode.Failure)
 			Sys.stderr().writeString('Unexpected result for $file: $compileResult, expected $expectedResult\n');
 		return result;
+	}
+	
+	static function getCompileArgs(file:String, target:Target):Array<String> {
+		var compileArgs = ["-main", "Main", '-$target', target];
+		var haxelibs = haxelibs[file];
+		if (haxelibs != null) {
+			for (haxelib in haxelibs) {
+				compileArgs.push("-lib");
+				compileArgs.push(haxelib);
+			}
+		}
+		return compileArgs;
 	}
 	
 	static function getResult(results:Array<ExitCode>):ExitCode {

--- a/tests/RunTravis.hx
+++ b/tests/RunTravis.hx
@@ -8,9 +8,13 @@ using StringTools;
 abstract Target(String) from String to String
 {
 	var Swf = "swf";
+	var As3 = "as3";
 	var Js = "js";
-	var Neko= "neko";
+	var Neko = "neko";
 	var Cpp = "cpp";
+	var Cs = "cs";
+	var Java = "java";
+	var Python = "python";
 }
 
 @:enum

--- a/tests/RunTravis.hx
+++ b/tests/RunTravis.hx
@@ -1,0 +1,139 @@
+package;
+
+import sys.FileSystem;
+import sys.io.File;
+using StringTools;
+
+@:enum
+abstract Target(String) from String to String
+{
+	var Swf = "swf";
+	var Js = "js";
+	var Neko= "neko";
+	var Cpp = "cpp";
+}
+
+@:enum
+abstract ExitCode(Int) from Int to Int
+{
+	var Success = 0;
+	var Failure = 1;
+	
+	@:from
+	static function fromBool(b:Bool):ExitCode {
+		return b ? ExitCode.Success : ExitCode.Failure;
+	}
+}
+
+class RunTravis
+{
+	/** Examples that are expected to fail / *should* produce a compiler error. */
+	static var requiredFailures = [
+		"AbstractExposeTypeOperations.hx",
+		"DynamicInferenceIssue.hx",
+		"ExprOf.hx",
+		"Extractor5.hx",
+		"GetterSetter2.hx",
+		"Property4.hx",
+		"SelectiveFunction.hx",
+		"Test.hx"
+	];
+	
+	/** Examples that are not included in the tests. */
+	static var excludedExamples = [
+		"Color.hx",
+		"ClassExpose.hx", // no main
+		"FunctionTypeParameter.hx",
+		"HaxelibRandom.hx", // needs a haxelib
+		"HelloPHP.hx", // PHP only
+		"ImplicitTransitiveCast.hx",
+		"JSRequireModule.hx",
+		"JSRequireObject.hx",
+		"Point.hx",
+		"Point3.hx",
+		"StringInterpolation.hx",
+		"StructureField.hx",
+		"SwitchEnum.hx",
+		"SwitchStatement.hx",
+		"UnitTestCase.hx",
+		"UnitTestRunner.hx",
+		"UnitTestSetup.hx",
+		"Variance.hx",
+		"Visibility.hx",
+		"Visibility2.hx",
+		"WhileLoop.hx"
+	];
+	
+	/**
+		Additional .hx modules needed to compile an example -
+		these are not compiled themselves, but copied to /bin.
+	*/
+	static var additionalModules = [
+		"AutoBuildingMacro.hx",
+		"EnumBuildingMacro.hx",
+		"MathStaticExtension.hx",
+		"TypeBuildingMacro.hx"
+	];
+	
+	public static function main():Void {
+		var target:Target = Sys.getEnv("TARGET");
+		if (target == null) {
+			Sys.println("No TARGET defined. Defaulting to neko.");
+			target = Target.Neko;
+		}
+		
+		excludedExamples = excludedExamples.concat(additionalModules);
+		Sys.exit(getResult([
+			buildExamples(target)
+		]));
+	}
+	
+	static function buildExamples(target:Target):ExitCode {
+		Sys.println("\nBuilding Haxe Manual examples...\n");
+		Sys.setCwd("../HaxeManual/assets");
+	
+		var examples = FileSystem.readDirectory(".").filter(function(f) {
+			return f.endsWith(".hx") && excludedExamples.indexOf(f) == -1;
+		});
+	
+		FileSystem.createDirectory("bin");
+		for (additionalModule in additionalModules)
+			File.copy(additionalModule, 'bin/$additionalModule');
+	
+		return getResult([for (example in examples) compile(example, target)]);
+	}
+	
+	static function compile(file:String, target:Target):ExitCode {
+		// workaround for "Module [name] does not define type [name]"
+		File.copy(file, "bin/Main.hx");
+	
+		return runInDir("bin", function() {
+			return hasExpectedResult(file, target);
+		});
+	}
+	
+	static function hasExpectedResult(file:String, target:Target):ExitCode {
+		var expectedResult:ExitCode = requiredFailures.indexOf(file) == -1;
+		var compileResult = Sys.command("haxe", ["-main", "Main", '-$target', target]);
+		
+		var result:ExitCode = compileResult == expectedResult;
+		if (result == ExitCode.Failure)
+			Sys.stderr().writeString('Unexpected result for $file: $compileResult, expected $expectedResult\n');
+		return result;
+	}
+	
+	static function getResult(results:Array<ExitCode>):ExitCode {
+		for (result in results)
+			if (result != ExitCode.Success)
+			return ExitCode.Failure;
+		return ExitCode.Success;
+	}
+	
+	static function runInDir(dir:String, func:Void->ExitCode):ExitCode {
+		var oldCwd = Sys.getCwd();
+		Sys.setCwd(dir);
+		var result = func();
+		Sys.setCwd(oldCwd);
+		return result;
+	}
+}

--- a/tests/RunTravis.hx
+++ b/tests/RunTravis.hx
@@ -121,7 +121,7 @@ class RunTravis
 		
 		var result:ExitCode = compileResult == expectedResult;
 		if (result == ExitCode.Failure)
-			Sys.stderr().writeString('Unexpected result for $file: $compileResult, expected $expectedResult\n');
+			printError('Unexpected result for $file: $compileResult, expected $expectedResult');
 		return result;
 	}
 	
@@ -142,6 +142,19 @@ class RunTravis
 			if (result != ExitCode.Success)
 			return ExitCode.Failure;
 		return ExitCode.Success;
+	}
+	
+	static function printError(error:String):Void {
+		setColor(31); // red
+		Sys.println(error);
+		setColor(); // no color
+	}
+	
+	static function setColor(?colorId:Int):Void {
+		if (Sys.systemName() == "Linux") {
+			var id = (colorId == null) ? "" : ';$colorId';
+			Sys.stderr().writeString("\033[0" + id + "m");
+		}
 	}
 	
 	static function runInDir(dir:String, func:Void->ExitCode):ExitCode {

--- a/tests/RunTravis.hx
+++ b/tests/RunTravis.hx
@@ -63,6 +63,7 @@ class RunTravis
 		"JSRequireObject.hx",
 		"Point.hx",
 		"Point3.hx",
+		"RestAndEitherType.hx", // requires an extern
 		"StringInterpolation.hx",
 		"StructureField.hx",
 		"SwitchEnum.hx",

--- a/tests/RunTravis.hx
+++ b/tests/RunTravis.hx
@@ -83,7 +83,7 @@ class RunTravis
 		"GenericBuild1.hx" => "GenericBuildMacro1.hx",
 		"GenericBuild2.hx" => "GenericBuildMacro2.hx",
 		"MathExtensionUsage.hx" => "MathStaticExtension.hx",
-		"TypeBuilding" => "TypeBuildingMacro.hx"
+		"TypeBuilding.hx" => "TypeBuildingMacro.hx"
 	];
 	
 	static var haxelibs = [

--- a/tests/RunTravis.hx
+++ b/tests/RunTravis.hx
@@ -76,17 +76,14 @@ class RunTravis
 		"WhileLoop.hx"
 	];
 	
-	/**
-		Additional .hx modules needed to compile an example -
-		these are not compiled themselves, but copied to /bin.
-	*/
+	/** Additional .hx modules needed to compile specific examples. */
 	static var additionalModules = [
-		"AutoBuildingMacro.hx",
-		"EnumBuildingMacro.hx",
-		"GenericBuildMacro1.hx",
-		"GenericBuildMacro2.hx",
-		"MathStaticExtension.hx",
-		"TypeBuildingMacro.hx"
+		"AutoBuilding.hx" => "AutoBuildingMacro.hx",
+		"EnumBuilding.hx" => "EnumBuildingMacro.hx",
+		"GenericBuild1.hx" => "GenericBuildMacro1.hx",
+		"GenericBuild2.hx" => "GenericBuildMacro2.hx",
+		"MathExtensionUsage.hx" => "MathStaticExtension.hx",
+		"TypeBuilding" => "TypeBuildingMacro.hx"
 	];
 	
 	static var haxelibs = [
@@ -100,7 +97,9 @@ class RunTravis
 			target = Target.Neko;
 		}
 		
-		excludedExamples = excludedExamples.concat(additionalModules);
+		for (additionalModule in additionalModules)
+			excludedExamples.push(additionalModule);
+		
 		Sys.exit(getResult([
 			buildExamples(target)
 		]));
@@ -130,10 +129,16 @@ class RunTravis
 	}
 	
 	static function compile(file:String, target:Target):ExitCode {
+		var dir = "bin/" + getFileName(file);
+		FileSystem.createDirectory(dir);
 		// workaround for "Module [name] does not define type [name]"
-		File.copy(file, "bin/Main.hx");
+		File.copy(file, '$dir/Main.hx');
 	
-		return runInDir("bin", function() {
+		var additional = additionalModules.get(file);
+		if (additional != null)
+			File.copy(additional, '$dir/$additional');
+		
+		return runInDir(dir, function() {
 			return hasExpectedResult(file, target);
 		});
 	}
@@ -187,5 +192,10 @@ class RunTravis
 		var result = func();
 		Sys.setCwd(oldCwd);
 		return result;
+	}
+	
+	static function getFileName(file:String):String {
+		var dotIndex = file.lastIndexOf(".");
+		return file.substring(0, dotIndex);
 	}
 }

--- a/tests/RunTravis.hx
+++ b/tests/RunTravis.hx
@@ -70,6 +70,8 @@ class RunTravis
 	static var additionalModules = [
 		"AutoBuildingMacro.hx",
 		"EnumBuildingMacro.hx",
+		"GenericBuildMacro1.hx",
+		"GenericBuildMacro2.hx",
 		"MathStaticExtension.hx",
 		"TypeBuildingMacro.hx"
 	];

--- a/tests/RunTravis.hx
+++ b/tests/RunTravis.hx
@@ -91,7 +91,7 @@ class RunTravis
 	];
 	
 	public static function main():Void {
-		var target:Target = Sys.getEnv("TARGET");
+		var target:Target = Sys.args()[0];
 		if (target == null) {
 			Sys.println("No TARGET defined. Defaulting to neko.");
 			target = Target.Neko;
@@ -101,16 +101,18 @@ class RunTravis
 			excludedExamples.push(additionalModule);
 		
 		Sys.exit(getResult([
-			buildExamples(target)
+			buildExamples(target, Sys.args().slice(1))
 		]));
 	}
 	
-	static function buildExamples(target:Target):ExitCode {
+	static function buildExamples(target:Target, ?included:Array<String>):ExitCode {
 		Sys.println("\nBuilding Haxe Manual examples...\n");
 		Sys.setCwd("../HaxeManual/assets");
 	
 		var examples = FileSystem.readDirectory(".").filter(function(f) {
 			return f.endsWith(".hx") && excludedExamples.indexOf(f) == -1;
+		}).filter(function(f) {
+			return included.length == 0 || included.indexOf(f) != -1;
 		});
 	
 		FileSystem.createDirectory("bin");

--- a/tests/RunTravis.hxml
+++ b/tests/RunTravis.hxml
@@ -1,0 +1,2 @@
+-main RunTravis
+-neko RunTravis.n

--- a/tests/RunTravis.hxproj
+++ b/tests/RunTravis.hxproj
@@ -1,0 +1,53 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<project version="2">
+  <!-- Output SWF options -->
+  <output>
+    <movie outputType="Application" />
+    <movie input="" />
+    <movie path="RunTravis.hxml" />
+    <movie fps="0" />
+    <movie width="0" />
+    <movie height="0" />
+    <movie version="0" />
+    <movie minorVersion="0" />
+    <movie platform="hxml" />
+    <movie background="#FFFFFF" />
+  </output>
+  <!-- Other classes to be compiled into your SWF -->
+  <classpaths>
+    <class path="." />
+  </classpaths>
+  <!-- Build options -->
+  <build>
+    <option directives="" />
+    <option flashStrict="False" />
+    <option noInlineOnDebug="False" />
+    <option mainClass="RunTravis" />
+    <option enabledebug="False" />
+    <option additional="" />
+  </build>
+  <!-- haxelib libraries -->
+  <haxelib>
+    <!-- example: <library name="..." /> -->
+  </haxelib>
+  <!-- Class files to compile (other referenced classes will automatically be included) -->
+  <compileTargets>
+    <!-- example: <compile path="..." /> -->
+  </compileTargets>
+  <!-- Paths to exclude from the Project Explorer tree -->
+  <hiddenPaths>
+    <hidden path="obj" />
+  </hiddenPaths>
+  <!-- Executed before build -->
+  <preBuildCommand>cmd /c haxe $(OutputFile)</preBuildCommand>
+  <!-- Executed after build -->
+  <postBuildCommand alwaysRun="False" />
+  <!-- Other project options -->
+  <options>
+    <option showHiddenPaths="False" />
+    <option testMovie="Unknown" />
+    <option testMovieCommand="" />
+  </options>
+  <!-- Plugin storage -->
+  <storage />
+</project>


### PR DESCRIPTION
I had to make some changes to make some of the examples testable, like renaming the classes to `Main` (this also makes things more consistent) and moving macros into separate modules.

All targets on both Haxe 3.2.0 and the dev branch are tested - they're [all green for the dev branch right now](https://travis-ci.org/Gama11/HaxeManual/builds/66239660), but not 3.2.0 due to several issues. Not sure what the best way to deal with that is:

- add the examples in question to the list of excluded examples
- allow failures for all 3.2.0 builds in the travis file
- wait for a Haxe 3.2.1 release? :)

The first argument to the neko test runner specifies the target. All subsequent arguments specify a specific example file that should be built. If any are specified, only those will be built (instead of building all when none are specified).