### PR TITLE
Travis: less excluded examples

### DIFF
--- a/HaxeManual/assets/FunctionTypeParameter.hx
+++ b/HaxeManual/assets/FunctionTypeParameter.hx
@@ -1,4 +1,4 @@
-class FunctionTypeParameter {
+class Main {
   static public function main() {
     equals(1, 1);
     // runtime message: bar should be foo

--- a/HaxeManual/assets/StringInterpolation.hx
+++ b/HaxeManual/assets/StringInterpolation.hx
@@ -1,5 +1,5 @@
 var x = 12;
-// Concatenating Approach
+// Concatenating approach
 trace('The value of x is ' + x);
 
 // With String Interpolation;

--- a/HaxeManual/assets/SwitchEnum.hx
+++ b/HaxeManual/assets/SwitchEnum.hx
@@ -1,16 +1,17 @@
-enum Color{
+enum Color {
   Red;
   Green;
   Blue;
 }
 
-var myColor : Color
+class Main {
+  static function main() {
+    var myColor : Color = Blue;
 
-//...
-
-switch( myColor ){
-  case Red: 0xFF0000;
-  case Green: 0x00ff00;
+    // compiler error: Unmatched patterns: Blue
+    switch( myColor ){
+      case Red: 0xFF0000;
+      case Green: 0x00ff00;
+    }
+  }
 }
-// will cause a compile warning because 'Blue'
-// is missing

--- a/tests/Helper.hx
+++ b/tests/Helper.hx
@@ -1,0 +1,9 @@
+package;
+
+<module>
+
+class Main {
+	static function main() {
+		<function>
+	}
+}


### PR DESCRIPTION
- moved some examples from `excludedExamples` to `requiredFailures` where they should be
- added some hackery to insert snippets that aren't compiable on their own into a .hx file as modules / the body of the main function (:D)
- rewrote `Color.hx` to be compilable