### PR TITLE
Add instantiation reification syntax

### DIFF
--- a/HaxeManual/09-macros.tex
+++ b/HaxeManual/09-macros.tex
@@ -105,6 +105,7 @@ This kind of reification only works in places where the internal structure expec
 	\item field name \expr{\{ \$name: 1\} }
 	\item function name \expr{function \$name() \{ \}}
 	\item catch variable name \expr{try e() catch(\$name:Dynamic) \{\}}
+	\item instantiation \expr{new \$name() \{ \}}
 \end{itemize}
 
 

--- a/HaxeManual/09-macros.tex
+++ b/HaxeManual/09-macros.tex
@@ -105,7 +105,7 @@ This kind of reification only works in places where the internal structure expec
 	\item field name \expr{\{ \$name: 1\} }
 	\item function name \expr{function \$name() \{ \}}
 	\item catch variable name \expr{try e() catch(\$name:Dynamic) \{\}}
-	\item instantiation \expr{new \$name() \{ \}}
+	\item instantiation \expr{new \$typePath() \{ \}}
 \end{itemize}
 
 


### PR DESCRIPTION
I had [this question ](http://stackoverflow.com/questions/32179173/how-to-declare-instantiation-in-haxe-macro-function) about instantiation within a macro function. It seems to exist but it's not very documented well. I found the [Expression Reification page](http://haxe.org/manual/macro-reification-expression.html) only says `function $name() { }` from which you _could guess_ the syntax exist.

I'm not sure if we should also mention that a full path should be given here.