### PR TITLE
Fixed " conversion of single quoted empty string

### DIFF
--- a/HaxeManual/05-expressions.tex
+++ b/HaxeManual/05-expressions.tex
@@ -62,7 +62,7 @@ The Haxe syntax supports the following constants:
 \begin{description}
 	\item[Int:] An \tref{integer}{define-int}, such as \expr{0}, \expr{1}, \expr{97121}, \expr{-12}, \expr{0xFF0000}.
 	\item[Float:] A \tref{floating point number}{define-float}, such as \expr{0.0}, \expr{1.}, \expr{.3}, \expr{-93.2}.
-	\item[String:] A \tref{string of characters}{define-string}, such as \expr{""}, \expr{"foo"}, \expr{''}, \expr{'bar'}.
+	\item[String:] A \tref{string of characters}{define-string}, such as \expr{""}, \expr{"foo"}, \expr{'{'}}, \expr{'bar'}.
 	\item[true,false:] A \tref{boolean}{define-bool} value.
 	\item[null:] The null value.
 \end{description}


### PR DESCRIPTION
Changed \expr{''} to \expr{'{'}} in Constants section

See http://haxe.org/manual/expression-constants.html right before 'bar' for the problem. This is undesired behavior in this particular instance in the manual.