### PR TITLE
Explain super.method()

### DIFF
--- a/HaxeManual/04-class-field.tex
+++ b/HaxeManual/04-class-field.tex
@@ -199,7 +199,7 @@ Overriding fields is instrumental for creating class hierarchies. Many design pa
 
 \haxe{assets/Override.hx}
 
-The important components here are
+The important components here are:
 
 \begin{itemize}
 	\item the class \type{Base} which has a method \expr{myMethod} and a constructor,
@@ -207,7 +207,14 @@ The important components here are
 	\item the \type{Main} class whose \expr{main} method creates an instance of \expr{Child}, assigns it to a variable \expr{child} of explicit type \type{Base} and calls \expr{myMethod()} on it.
 \end{itemize}
 
-The variable \expr{child} is explicitly typed as \type{Base} to highlight an important difference: At compile-time the type is known to be \type{Base}, but the runtime still finds the correct method \expr{myMethod} on class \type{Child}. It is then obvious that the field access is resolved dynamically at runtime.
+The variable \expr{child} is explicitly typed as \type{Base} to highlight an important difference: At compile-time the type is known to be \type{Base}, but the runtime still finds the correct method \expr{myMethod} on class \type{Child}. This is because field access is resolved dynamically at runtime.
+
+The \type{Child} class can access methods it has overriden by calling \expr{super.methodName()}:
+
+\haxe{assets/OverrideCallParent.hx}
+
+The section on \Fullref{types-class-inheritance} explains the use of \expr{super()} from within a \expr{new} constructor.
+
 
 \subsection{Effects of variance and access modifiers}
 \label{class-field-override-effects}

--- a/HaxeManual/assets/OverrideCallParent.hx
+++ b/HaxeManual/assets/OverrideCallParent.hx
@@ -1,0 +1,24 @@
+class Base {
+  public function new() { }
+  public function myMethod() {
+    return "Base";
+  }
+}
+
+class Child extends Base {
+  public override function myMethod() {
+    return "Child";
+  }
+
+  public function callHome() {
+    return super.myMethod();
+  }
+
+}
+
+class Main {
+  static public function main() {
+    var child = new Child();
+    trace(child.callHome()); // Base
+  }
+}


### PR DESCRIPTION
I had to hit SO for an answer on how to access parent methods that had been overridden.  The person who answered the question linked to this page, which didn't explain the syntax. Now it does : )

Includes minor punctuation and wording changes to the original.