### PR TITLE
add missing script close tag

### DIFF
--- a/HaxeManual/12-target-details.tex
+++ b/HaxeManual/12-target-details.tex
@@ -54,7 +54,7 @@ To display the output in a browser, create an HTML-document called \ic{index.htm
 <!DOCTYPE html>
 <html>
 	<body>
-		<script src="main-javascript.js">
+		<script src="main-javascript.js"></script>
 	</body>
 </html>
 \end{lstlisting}


### PR DESCRIPTION
Unless the the script tag is properly closed the example seems not to work under Chrome v48