### PR TITLE
Rename completion section to "Compiler Services"

### DIFF
--- a/HaxeManual/08-compiler-features.tex
+++ b/HaxeManual/08-compiler-features.tex
@@ -157,7 +157,7 @@ The compiler automatically defines the flag \expr{dce} with a value of either \e
 
 
 
-\section{Completion}
+\section{Compiler Services}
 \label{cr-completion}
 \state{NoContent}
 


### PR DESCRIPTION
I updated the title only for now. I left the label the same, so we don't have new url's on Google on the section.

Closes https://github.com/HaxeFoundation/HaxeManual/issues/171 ?