### PR TITLE
added HXCPP_OPTIMIZE_FOR_SIZE

### DIFF
--- a/HaxeManual/12-target-details.tex
+++ b/HaxeManual/12-target-details.tex
@@ -618,6 +618,7 @@ var isFalse = untyped __physeq__(false, value);
 	\item HXCPP_STRICT_CASTS
 	\item HXCPP_VISIT_ALLOCS
 	\item HXCPP_WINXP_COMPAT
+	\item HXCPP_OPTIMIZE_FOR_SIZE
 	\item IPHONE_VER
 	\item LEGACY_MACOSX_SDK
 	\item LEGACY_XCODE_LOCATION


### PR DESCRIPTION
As continue of pull-request https://github.com/HaxeFoundation/hxcpp/pull/334 what merged into HaxeFoundation:master 5 days ago.

>When creating non-gaming apps for mobile devices optimization for APK size may be desirable. Specifying the compiler flags -Os, -fno-asynchronous-unwind-tables and the linker flag -Wl,--gc-sections reduced the size of a test haxeui APK by 25%.
>
>The compiler flag -Os is described in the gcc manual with: -Os enables all -O2 optimizations that do not typically increase code size.
>
>With this pull request, the new HXCPP_OPTIMIZE_FOR_SIZE switch will be introduced for the Android toolchain, which - if specified - enables the mentioned compiler/linker flags.
>
>openfl projects can now for example use:
>
>```xml
<haxedef name="HXCPP_OPTIMIZE_FOR_SIZE" if="android" />
```