### PR TITLE
Change the "Based on work" link

### DIFF
--- a/HaxeManual/01-introduction.tex
+++ b/HaxeManual/01-introduction.tex
@@ -84,7 +84,7 @@ Most of this document's content was written by Simon Krajewski while working for
 
 The Haxe Manual by \href{http://haxe.org/foundation}{Haxe Foundation} is licensed under a \href{http://creativecommons.org/licenses/by/4.0/}{Creative Commons Attribution 4.0 International License}.
 
-Based on a work at \href{https://github.com/HaxeFoundation/HaxeManual}{https://github.com/HaxeFoundation/HaxeManual}.
+Based on a work at \href{https://github.com/HaxeFoundation/HaxeManual}{Haxe Manual on GitHub}.
 
 \section{Hello World}
 \label{introduction-hello-world}


### PR DESCRIPTION
The source as is displays the single link on the browser (tested on Firefox and Chrome)  "\[https://github.com/HaxeFoundation/HaxeManual](https://github.com/HaxeFoundation/HaxeManual)". So, as expected, this redirects the user to a 404 page on github. I don't think this is intendend.

I changed the link description to "Haxe Manual on GitHub", but it's just a suggestion. You may have a better description for it.