### PR TITLE
Fixed opening parenthesis expr typo

### DIFF
--- a/HaxeManual/05-expressions.tex
+++ b/HaxeManual/05-expressions.tex
@@ -252,7 +252,7 @@ However, there are some differences related to type parameters and the position 
 \section{new}
 \label{expression-new}
 
-The \expr{new} keyword signals that a \tref{class}{types-class-instance} or an \tref{abstract}{types-abstract} is being instantiated. It is followed by the \tref{type path}{define-type-path} of the type which is to be instantiated. It may also list explicit \tref{type parameters}{type-system-type-parameters} enclosed in \expr{<>} and separated by comma \expr{,}. After an opening parenthesis \expr{()} follow the constructor arguments, again separated by comma \expr{,}, with a closing parenthesis \expr{)} at the end.
+The \expr{new} keyword signals that a \tref{class}{types-class-instance} or an \tref{abstract}{types-abstract} is being instantiated. It is followed by the \tref{type path}{define-type-path} of the type which is to be instantiated. It may also list explicit \tref{type parameters}{type-system-type-parameters} enclosed in \expr{<>} and separated by comma \expr{,}. After an opening parenthesis \expr{(} follow the constructor arguments, again separated by comma \expr{,}, with a closing parenthesis \expr{)} at the end.
 
 \haxe{assets/New.hx}
 


### PR DESCRIPTION
Typo: [...] After an opening parenthesis \expr{()} [...]
Fixed: [...] After an opening parenthesis \expr{(} [...]