### PR TITLE
Built-in Compiler Metadata: fix misleading abstract link

### DIFF
--- a/HaxeManual/08-compiler-features.tex
+++ b/HaxeManual/08-compiler-features.tex
@@ -13,7 +13,7 @@ Starting from Haxe 3.0, you can get the list of defined compiler metadata by run
 	\multicolumn{3}{|c|}{Global metadata} \\ \hline
 	Metadata &  Description  &  Platform \\ \hline
 	@:abi & Function ABI/calling convention  & cpp \\
-	@:abstract &  Sets the underlying class implementation as \tref{abstract type}{types-abstract}  &  cs  java \\
+	@:abstract &  Sets the underlying class implementation as 'abstract'  &  cs  java \\
 	@:access \_(Target path)\_  &   Forces private access to package  type or field,  see \tref{Access Control}{lf-access-control}  &  all \\
 	@:allow \_(Target path)\_  &   Allows private access from package  type or field,  see \tref{Access Control}{lf-access-control}  &  all \\
 	@:analyzer & Used to configure the static analyzer  &  all \\


### PR DESCRIPTION
@:abstract is for abstract classes and has nothing to do with Haxe abstracts.