### PR TITLE
[TravisCI] install hxcpp from git for Haxe dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,7 +81,6 @@ matrix:
       haxe: development
 
 install:
-  - haxelib install hxcpp > /dev/null
   - haxelib install hxcs > /dev/null
   - haxelib install hxjava > /dev/null
   - haxelib install random > /dev/null

--- a/tests/RunTravis.hxproj
+++ b/tests/RunTravis.hxproj
@@ -2,7 +2,7 @@
 <project version="2">
   <!-- Output SWF options -->
   <output>
-    <movie outputType="Application" />
+    <movie outputType="CustomBuild" />
     <movie input="" />
     <movie path="RunTravis.hxml" />
     <movie fps="0" />


### PR DESCRIPTION
Haxe dev + hxcpp dev is still failing (https://travis-ci.org/Gama11/HaxeManual/builds/119791367), but with different errors, so I guess hxcpp from git is installed correctly. This code is also pretty much copied 1:1 from Flixel's `RunTravis.hx`, and it seems to work there.

Now it errors with:

```
Error: /home/travis/haxe/lib/hxcpp/git/src/hx/CFFI.cpp: In function ‘void val_array_set_size(hx::Object*, int)’:
/home/travis/haxe/lib/hxcpp/git/src/hx/CFFI.cpp:410:77: error: cannot dynamic_cast ‘arg1’ (of type ‘class hx::Object*’) to type ‘struct cpp::VirtualArray_obj*’ (target is not pointer or reference to complete type)
/home/travis/haxe/lib/hxcpp/git/src/hx/CFFI.cpp:412:12: error: invalid use of incomplete type ‘struct cpp::VirtualArray_obj’
/home/travis/haxe/lib/hxcpp/git/include/hxcpp.h:239:12: error: forward declaration of ‘struct cpp::VirtualArray_obj’
```

instead of:

```
Error: In file included from ./src/haxe/ds/StringMap.cpp:7:0:
include/haxe/ds/StringMap.h:34:3: error: ‘Val’ in namespace ‘hx’ does not name a type
include/haxe/ds/StringMap.h:35:3: error: ‘Val’ in namespace ‘hx’ does not name a type
./src/haxe/ds/StringMap.cpp:120:1: error: ‘Val’ in namespace ‘hx’ does not name a type
./src/haxe/ds/StringMap.cpp:133:1: error: ‘Val’ in namespace ‘hx’ does not name a type
```

The new errors seem related to https://github.com/HaxeFoundation/haxe/issues/5004.