### PR TITLE
[TravisCI] add cppia, hl and lua builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,6 +63,9 @@ matrix:
     - env: TARGET=cpp
       haxe: development
 
+    - env: TARGET=cppia
+      haxe: development
+
     - env: TARGET=cs
       haxe: 3.2.0
       addons: {apt: {packages: [mono-devel, mono-mcs]}}
@@ -78,6 +81,12 @@ matrix:
     - env: TARGET=python
       haxe: 3.2.0
     - env: TARGET=python
+      haxe: development
+
+    - env: TARGET=hl
+      haxe: development
+
+    - env: TARGET=lua
       haxe: development
 
 install:

--- a/tests/RunTravis.hx
+++ b/tests/RunTravis.hx
@@ -12,9 +12,12 @@ abstract Target(String) from String to String
 	var Js = "js";
 	var Neko = "neko";
 	var Cpp = "cpp";
+	var Cppia = "cppia";
 	var Cs = "cs";
 	var Java = "java";
 	var Python = "python";
+	var Hl = "hl";
+	var Lua = "lua";
 }
 
 @:enum


### PR DESCRIPTION
Lua is currently going to fail because the Linux64 Haxe builds are outdated.