### PR TITLE
Small typo

### DIFF
--- a/HaxeManual/02-types.tex
+++ b/HaxeManual/02-types.tex
@@ -369,7 +369,7 @@ Semantically, this enum describes a color which is either red, green, blue or a 
 \end{itemize}
 The Haxe type system provides a type which unifies with all enum types:
 
-\define[Type]{\expr{Enum$<$T$>$}}{define-enum-t}{This type is compatible with all enum types. At compile-time, \type{Enum<T>} can bee seen as the common base type of all enum types. However, this relation is not reflected in generated code.} 
+\define[Type]{\expr{Enum$<$T$>$}}{define-enum-t}{This type is compatible with all enum types. At compile-time, \type{Enum<T>} can be seen as the common base type of all enum types. However, this relation is not reflected in generated code.} 
 \todo{Same as in 2.2, what is \type{Enum$<$T$>$} syntax?}
 
 \subsection{Enum Constructor}


### PR DESCRIPTION
`be` instead of `bee`