### PR TITLE
Don't download/generate PDF in Travis anymore

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,10 @@ sudo: false
 matrix:
   include:
     - sudo: required
-      install:
-        - haxelib install convert-markdown.hxml
+      install:		
+        - haxelib git hxargs https://github.com/Simn/hxargs.git		
+        - haxelib git hxparse https://github.com/Simn/hxparse.git
         # spellcheck
-
         - nvm install 6.4
         - npm install -g markdown-spellcheck
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,41 +6,14 @@ matrix:
   include:
     - sudo: required
       install:
-        - sudo apt-get install calibre -qq
-        - mkdir -p ~/Downloads
-        - pushd ~/Downloads
-        # install fonts
-        - mkdir -p ~/.fonts
-        - wget https://github.com/adobe-fonts/source-code-pro/archive/2.010R-ro/1.030R-it.zip
-        - unzip 1.030R-it.zip
-        - cp source-code-pro-2.010R-ro-1.030R-it/OTF/*.otf ~/.fonts/
-        - wget https://github.com/adobe-fonts/source-sans-pro/archive/2.010R-ro/1.065R-it.zip
-        - unzip 1.065R-it.zip
-        - cp source-sans-pro-2.010R-ro-1.065R-it/OTF/*.otf ~/.fonts/
-        - fc-cache -f -v
-        # texlive
-        - sudo add-apt-repository ppa:texlive-backports/ppa -y
-        - sudo apt-get update
-        - sudo apt-get install texlive-xetex texlive-latex-extra -y
-        # pandoc
-        - wget https://github.com/jgm/pandoc/releases/download/1.15.0.6/pandoc-1.15.0.6-1-amd64.deb
-        - sudo dpkg -i pandoc-1.15.0.6-1-amd64.deb
-        # mupdf
-        - curl -s -L --retry 3 http://mupdf.com/downloads/archive/mupdf-1.7a-source.tar.gz | tar -C . -x -z -f -
-        - pushd mupdf-1.7a-source
-        -   make HAVE_X11=no
-        -   sudo make HAVE_X11=no install
-        - popd
-        # haxelibs
-        - haxelib git hxargs https://github.com/Simn/hxargs.git
-        - haxelib git hxparse https://github.com/Simn/hxparse.git
-        - popd
+        - haxelib install convert-markdown.hxml
         # spellcheck
+
         - nvm install 6.4
         - npm install -g markdown-spellcheck
       script:
         - pushd convert
-        -   haxe convert.hxml -D recompileEnv
+        -   haxe convert-markdown.hxml -D recompileEnv
         - popd
         - mdspell *.md "output/*/website/**/*.md" --ignore-numbers --ignore-acronyms --report
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,12 @@ Finally, if you want to contribute to the Haxe Manual but cannot be arsed to use
 Generating Markdown
 -----------------
 
-Run [convert/convert.hxml](convert/convert.hxml) to generate the markdown which will be exported to the [output-folder](output/). For quick testing disable the .mobi generation.
+Run <convert/convert-markdown.hxml> to generate the markdown which will be exported to the [website output-folder](output/HaxeManual/website). 
+
+Generating the E-Book
+-----------------
+
+Run <convert/convert-ebook.hxml> to generate the ebook PDF which will be exported to the [ebook output-folder](output/HaxeManual/ebook). 
 
 You can use the following defines when using `convert` for additional features.
 

--- a/convert/convert-ebook.hxml
+++ b/convert/convert-ebook.hxml
@@ -1,5 +1,4 @@
 display.hxml
 -resource envTemplate.tex@tikzTemplate
--cmd neko convert.n -i ../HaxeManual -o ../output/HaxeManual/website/ HaxeManual.tex
 -cmd neko convert.n -i ../HaxeManual -o ../output/HaxeManual/ebook/HaxeManual.mobi HaxeManual.tex
 

--- a/convert/convert-markdown.hxml
+++ b/convert/convert-markdown.hxml
@@ -1,0 +1,3 @@
+display.hxml
+-cmd neko convert.n -i ../HaxeManual -o ../output/HaxeManual/website/ HaxeManual.tex
+


### PR DESCRIPTION
 * Latex libraries really slow down Travis. The resulting pdf-file isn't used anywhere, so that doesn't make it worth the waiting time (which is ~1.5 hours).
 * For convenience I created two hxml files.
 * Travis now only generates the markdown pure for testing and runs each example code in assets-folder on all targets.
 * Temporary fixes https://github.com/HaxeFoundation/HaxeManual/issues/288
* Unrelated, but let's not use git haxelib versions if it is not needed

This build should take less time: https://travis-ci.org/HaxeFoundation/HaxeManual/builds/240126143 Otherwise this PR is pointless.