### PR TITLE
Fix discrepancy between text and asset Haxe code

### DIFF
--- a/HaxeManual/06-language-features.tex
+++ b/HaxeManual/06-language-features.tex
@@ -413,7 +413,7 @@ Arrays can be matched on fixed length:
 
 \haxe[firstline=52,lastline=60]{assets/PatternMatching.hx}
 
-This will trace \expr{1} because \expr{array[1]} matches \expr{6}, and \expr{array[0]} is allowed to be anything.
+This will trace \expr{1} because \expr{myArray[1]} matches \expr{6}, and \expr{myArray[0]} is allowed to be anything.
 
 \subsection{Or patterns}
 \label{lf-pattern-matching-or}


### PR DESCRIPTION
In a nutshell, `array` in the text body is renamed to `myArray` in order to be aligned with the sample code.