### PR TITLE
Update 11-haxelib.tex

### DIFF
--- a/HaxeManual/11-haxelib.tex
+++ b/HaxeManual/11-haxelib.tex
@@ -1,4 +1,4 @@
 \chapter{Haxelib}
 \label{haxelib}
 
-Haxelib's documentation is available at \href{https://lib.haxe.org/documentation/using-haxelib/}{https://lib.haxe.org/documentation/using-haxelib/}.
+Haxelib's documentation is available at \href{https://lib.haxe.org/documentation/using-haxelib/}{lib.haxe.org/documentation/using-haxelib/}.


### PR DESCRIPTION
Fix rendered link

```
Haxelib's documentation is available at [https://lib.haxe.org/documentation/using-haxelib/](https://lib.haxe.org/documentation/using-haxelib/).
```

links to:

```
https://lib.haxe.org/documentation/using-haxelib/](https://lib.haxe.org/documentation/using-haxelib
```