### PR TITLE
Fix of the doc for Map Comprehension

### DIFF
--- a/HaxeManual/06-language-features.tex
+++ b/HaxeManual/06-language-features.tex
@@ -579,7 +579,7 @@ Variable \expr{a} is initialized to an \type{Map} holding keys from 0 to 4 and s
 
 \begin{lstlisting}
 var a = new Map();
-for (i in 0...5) a.set(i, 'number ${i++}');
+for (i in 0...5) a.set(i, 'number ${i}');
 \end{lstlisting}
 
 Variable \expr{b} is initialized to an \type{Map} with the same keys and values, but through a different comprehension style using \expr{while} instead of \expr{for}. Again, the following code would be equivalent:

--- a/HaxeManual/assets/MapComprehension.hx
+++ b/HaxeManual/assets/MapComprehension.hx
@@ -1,10 +1,10 @@
 class Main {
   static public function main() {
-    var a = [for (i in 0...10) i];
-    trace(a); // [0,1,2,3,4,5,6,7,8,9]
-
+    var a = [for (i in 0...5) i => 'number ${i}'];
+    trace(a); // {0 => number 0, 1 => number 1, 2 => number 2, 3 => number 3, 4 => number 4}
+    
     var i = 0;
-    var b = [while(i < 10) i++];
-    trace(b); // [0,1,2,3,4,5,6,7,8,9]
+    var b = [while(i < 5) i => 'number ${i++}'];
+    trace(b); // {0 => number 0, 1 => number 1, 2 => number 2, 3 => number 3, 4 => number 4}
   }
 }


### PR DESCRIPTION
The asset `MapComprehension.hx` was just a copy of `ArrayComprehension.hx`.
There was also an error in the equivalent code for the `for` loop example (`Loop variable cannot be modified`)