### PR TITLE
escape ampersand

### DIFF
--- a/HaxeManual/08-compiler-features.tex
+++ b/HaxeManual/08-compiler-features.tex
@@ -190,7 +190,7 @@ Due to Haxe being a very fast compiler, it is often sufficient to rely on the no
 
 \begin{itemize}
 	\item The position-argument can be set to 0 if the file in question contains a pipeline \ic{|} character at the position of interest. This is very useful for demonstration and testing as it allows us to ignore the byte-counting process a real IDE would have to do. The examples in this section are making use of this feature. Note that this only works in places where \ic{|} is not valid syntax otherwise, e.g. after dots (\ic{.|}) and opening parentheses (\ic{(|}).
-	\item The output is HTML-escaped so that \ic{\&}, \ic{<} and \ic{>} become \ic{\&amp;}, \ic{\&lt;} and \ic{\&gt;} respectively.
+	\item The output is HTML-escaped so that \ic{\&}, \ic{<} and \ic{>} become \ic{\&amp;amp;}, \ic{\&amp;lt;} and \ic{\&amp;gt;} respectively.
 	\item Otherwise any documentation output is preserved which means longer documentation might include new-line and tab-characters as it does in the source files.
 	\item When run in completion mode, the compiler does not display errors but instead tries to ignore them or recover from them.  If a critical error occurs while getting completion, the Haxe Compiler prints the error message instead of the completion output. Any non-XML output can be treated as a critical error message.
 \end{itemize}


### PR DESCRIPTION
Current version is
> The output is HTML-escaped so that &, < and > become &, < and > respectively.

but it should read like this
> The output is HTML-escaped so that &, < and > become &amp;amp;, &amp;lt; and &amp;gt; respectively.