### PR TITLE
Remove reference to -D old_browser

### DIFF
--- a/HaxeManual/10-std.tex
+++ b/HaxeManual/10-std.tex
@@ -783,7 +783,7 @@ The \href{http://api.haxe.org/haxe/Json.html}{haxe.Json} API automatically uses 
 
 Usage of Haxe own implementation can be forced with \expr{-D haxeJSON} compiler argument. This will also provide serialization of \tref{enums}{types-enum-instance} by their index, \tref{maps}{std-Map} with string keys and class instances.
 
-Older browsers (Internet Explorer 7, for instance) may not have native \emph{JSON} implementation. In case it's required to support them, we can include one of the JSON implementations available on the internet in the HTML page. Alternatively, a \expr{-D old_browser} compiler argument that will make \type{haxe.Json} try to use native JSON and, in case it's not available, fallback to its own implementation.
+Older browsers (Internet Explorer 7, for instance) may not have native \emph{JSON} implementation. In case it's required to support them, we can include one of the JSON implementations available on the internet in the HTML page.
 
 \section{Input/Output}
 \label{std-input-output}


### PR DESCRIPTION
This flag was removed in https://github.com/HaxeFoundation/haxe/pull/7477

See https://github.com/HaxeFoundation/haxe/issues/7091 for more details