### PR TITLE
Update outdated @:deprecated docs

### DIFF
--- a/HaxeManual/08-compiler-features.tex
+++ b/HaxeManual/08-compiler-features.tex
@@ -39,7 +39,7 @@ Starting from Haxe 3.0, you can get the list of defined compiler metadata by run
 	@:decl   &     &  cpp \\
 	@:delegate  &  Automatically added by \expr{-net-lib} on delegates   &  cs \\
 	@:depend  &     &  cpp \\
-	@:deprecated   &  Automatically added by \expr{-java-lib} on class fields annotated with \expr{@Deprecated} annotation. Has no effect on types compiled by Haxe  &  java \\
+	@:deprecated   &  Mark a type or field as deprecated  &  all \\
 	@:event  &  Automatically added by \expr{-net-lib} on events. Has no effect on types compiled by Haxe   &  cs \\
 	@:enum  &  Defines finite value sets to abstract definitions. See \tref{enum abstracts}{types-abstract-enum}  &  all \\
 	@:expose \_(?Name=Class path)\_  &  Makes the class available on the \expr{window} object or \expr{exports} for node.js. See \tref{exposing Haxe classes for JavaScript}{target-javascript-expose} &  js \\


### PR DESCRIPTION
Probably quite a few of them are outdated by now... this one seems particularly misleading though.