### PR TITLE
Changed description of function

### DIFF
--- a/HaxeManual/02-types.tex
+++ b/HaxeManual/02-types.tex
@@ -24,7 +24,7 @@ The Haxe type system knows seven type groups:
  \item[\emph{Class instance}:] an object of a given class or interface
  \item[\emph{Enum instance}:] a value of a Haxe enumeration
  \item[\emph{Structure}:] an anonymous structure, i.e. a collection of named fields
- \item[\emph{Function}:] a compound type of several arguments and one return
+ \item[\emph{Function}:] a compound type of several arguments and optionally return value
  \item[\emph{Dynamic}:] a wildcard type which is compatible with any type
  \item[\emph{Abstract}:] a compile-time type which is represented by a different type at runtime
  \item[\emph{Monomorph}:] an unknown type which may later become a different type


### PR DESCRIPTION
"a compound type of several arguments and one return" may be misunderstood as "one return statement", but in fact it means "one return value". Also, there might be no return value, i.e. [Any]->Void