### PR TITLE
Correct small typo

### DIFF
--- a/HaxeManual/02-types.tex
+++ b/HaxeManual/02-types.tex
@@ -139,7 +139,7 @@ Comparison involving at least one Dynamic value is unspecifed and platform-speci
 
 Haxe precedence differ from other languages for the following cases:
 \begin{itemize}
-	\item \expr{\%} have lower precedence than \expr{*} and \expr{/} whereas in C these three have the same
+	\item \expr{\%} has lower precedence than \expr{*} and \expr{/} whereas in C these three have the same
 	\item \expr{|}, \expr{\&} and \expr{\^} have the same precedence in Haxe, so they will be always grouped from left-to-right, whereas in C \expr{\&} have lower precedence than \expr{\^} which itself have lower precedence than \expr{|}
 	\item \expr{|}, \expr{\&} and \expr{\^} also have lower precedence than \expr{==} and \expr{!=} in Haxe
 \end{itemize}


### PR DESCRIPTION
% ~have~ **has** lower precedence than * and / whereas in C these three have the same

