### PR TITLE
Strings

### DIFF
--- a/HaxeManual/10-std.tex
+++ b/HaxeManual/10-std.tex
@@ -7,26 +7,97 @@
 
 \define[Type]{String}{define-string}{A String is a sequence of characters.}
 
+String is a special class in Haxe. It is not considered a \tref{basic type}{types-basic-types}, but it can be constructed as a \tref{literal}{std-String-literals}. The \tref{binary comparison operators}{expression-operator-binops} also behave differently when applied to strings. Haxe also supports special \tref{string interpolation}{lf-string-interpolation} syntax.
+
 \paragraph{Character code}
-Use the \ic{.code} property on a constant single-char string in order to compile its Unicode character point:
+Use the \ic{.code} property on a constant single-char string in order to compile its Unicode codepoint:
 
 \begin{lstlisting}
 "#".code // will compile as 35
 \end{lstlisting}
 
-\since{4.0.0}
-
-\paragraph{Unicode support}
-All Haxe targets except Neko support Unicode in strings by default.
-
-A string in Haxe code represents a valid sequence of Unicode codepoints. Due to differing internal representations of strings across targets, only the basic multilingual plane (BMP) is supported consistently: every BMP Unicode codepoint corresponds to exactly one string character.
-
-On some targets, the internal representation is UTF-16, which means that non-BMP Unicode codepoints are represented using surrogate pairs. It is still possible to work with strings on these targets without having to manually decode surrogate pairs by using the \href{https://api.haxe.org/v/development/haxe/iterators/StringIteratorUnicode.html}{Unicode iterators API} provided in the standard library.
-
 \paragraph{Related content}
 \begin{itemize}
 	\item See the \href{https://api.haxe.org/String.html}{String API} for details about its methods.
 \end{itemize} 
+
+\subsection{String literals}
+\label{std-String-literals}
+
+A string literal is a sequence of characters inside a pair of double quotes or single quotes:
+
+\begin{lstlisting}
+var a = "foo";
+var b = 'foo';
+trace(a == b); // true
+\end{lstlisting}
+
+The only difference between the two forms is that single-quoted literals allow \tref{string interpolation}{lf-string-interpolation}.
+
+\paragraph{Escape sequences}
+
+\begin{center}
+\begin{tabular}{| l | l | l | l | l |}
+	\hline
+	Sequence & Meaning & Unicode codepoint (decimal) & Unicode codepoint (hexadecimal) \\ \hline
+	\expr{\textbackslash{}t} & horizontal tab (TAB) & 9 & 0x09 \\
+	\expr{\textbackslash{}n} & new line (LF) & 10 & 0x0A \\
+	\expr{\textbackslash{}r} & new line (CR) & 13 & 0x0D \\
+	\expr{\textbackslash"} & double quote & 34 & 0x22 \\
+	\expr{\textbackslash'} & single quote & 39 & 0x27 \\
+	\expr{\textbackslash{}\textbackslash{}} & backslash & 92 & 0x5C \\
+	\expr{\textbackslash{}NNN} & ASCII escape where \expr{NNN} is 3 octal digits & 0 - 127 & 0x00 - 0x7F \\
+	\expr{\textbackslash{}xNN} & ASCII escape where \expr{NN} is a pair of hexadecimal digits & 0 - 127 & 0x00 - 0x7F \\
+	\expr{\textbackslash{}uNNNN} & Unicode escape where \expr{NNNN} is 4 hexadecimal digits & 0 - 65535 & 0x0000 - 0xFFFF \\
+	\expr{\textbackslash{}u\{N...\}} & Unicode escape where \expr{N...} is 1-6 hexadecimal digits & 0 - 1114111 & 0x000000 - 0x10FFFF \\ \hline
+\end{tabular}
+\end{center}
+
+\subsection{Unicode}
+\label{std-String-unicode}
+
+\since{4.0.0}
+
+All Haxe targets except Neko support Unicode in strings by default. The \tref{compile-time define}{lf-condition-compilation} \expr{target.unicode} is set on targets where Unicode is supported.
+
+A string in Haxe code represents a valid sequence of Unicode codepoints. Due to differing internal representations of strings across targets, only the basic multilingual plane (BMP) is supported consistently: every BMP Unicode codepoint corresponds to exactly one string character.
+
+It is still possible to work with strings including non-BMP characters on all targets without having to manually decode surrogate pairs by using the \href{https://api.haxe.org/v/development/haxe/iterators/StringIteratorUnicode.html}{Unicode iterators API} provided in the standard library.
+
+\subsection{Encoding}
+\label{std-String-encoding}
+
+On some targets, the internal representation is UTF-16, which means that non-BMP Unicode codepoints are represented using surrogate pairs. The \tref{compile-time define}{lf-condition-compilation} \expr{target.utf16} is set when the target uses UTF-16 internally.
+
+\paragraph{Null-bytes in strings}
+
+% Might need to be changed depending on the outcome of
+% https://github.com/HaxeFoundation/haxe/issues/8201
+
+Some Haxe targets disallow null-bytes (Unicode codepoint 0) in strings. Additionally, some Haxe core APIs assume a null-byte terminates strings. To consistently deal with binary data, including null-bytes, use the \href{https://api.haxe.org/haxe/io/Bytes.html}{haxe.io.Bytes} API.
+
+\paragraph{Target details}
+
+\begin{center}
+\begin{tabular}{| l | l | l | l | l |}
+	\hline
+	Target & \expr{target.unicode} & \expr{target.utf16} & Internal encoding & Null-byte allowed \\ \hline
+	Flash & yes & yes & UTF-16 & no \\
+	JavaScript & yes & yes & UTF-16 & yes (except in some old browsers) \\
+	ActionScript 3 & yes & yes & UTF-16 & no \\
+	C++ & yes & yes & ASCII or UTF-16 (if needed) & yes \\
+	Java & yes & yes & UTF-16 & yes \\
+	JVM & yes & yes & UTF-16 & yes \\
+	C\# & yes & yes & UTF-16 & yes \\
+	Python & yes & no & Latin-1, UCS-2, or UCS-4 (see \href{https://www.python.org/dev/peps/pep-0393/}{PEP 393}) & yes \\
+	Lua & yes & no & UTF-8 & yes \\
+	PHP & yes & no & binary & yes \\
+	Eval & yes & no & UTF-8 & yes \\
+	Neko & no & no & binary & yes \\
+	HashLink & yes & yes & UTF-16 & no \hline
+\end{tabular}
+\end{center}
+
 
 \section{Data Structures}
 \label{std-ds}

--- a/convert/src/LatexParser.hx
+++ b/convert/src/LatexParser.hx
@@ -317,6 +317,8 @@ class LatexParser extends Parser<LexerTokenSource<LatexToken>, LatexToken> imple
 					case [TBrOpen, s = text(), TBrClose]:
 						if (tableMode || s.indexOf("|") != -1) {
 							s = s.htmlEscape().replace("|", "&#124;").replace("_", "&#95;");
+							// https://github.com/dpeek/haxe-markdown/issues/31 :(
+							s = s.replace("\\\\", "\\\\\\\\\\\\\\\\");
 							'<code>$s</code>';
 						} else {
 							'`$s`';


### PR DESCRIPTION
Expand the `std-String` section:

 - Escape sequences in literals
 - Unicode details
 - Target-specific encoding

Closes #17, closes #380.