### PR TITLE
indentation: 2 spaces --> tab

### DIFF
--- a/content/05-expression.md
+++ b/content/05-expression.md
@@ -106,7 +106,7 @@ Blocks can contain local variables declared by [`var` expression](expression-var
 	{
 		a; // ok, a is available in sub-blocks
 	}
-  // ok, a is still available after
+	// ok, a is still available after
 	// sub-blocks	
 	a;
 }


### PR DESCRIPTION
Many code examples in this file use tabs, but this one line instead had 2 spaces, so converted to tab.