### PR TITLE
Fix wrong example code used for Array pattern matching

### DIFF
--- a/assets/PatternMatching6.hx
+++ b/assets/PatternMatching6.hx
@@ -1,13 +1,10 @@
-var myStructure = {
-  name: "haxe",
-  rating: "awesome"
-};
-var value = switch (myStructure) {
-    case {name: "haxe", rating: "poor"}:
-      throw false;
-    case {rating: "awesome", name: n}:
-      n;
-    case _:
-      "no awesome language found";
+var myArray = [1, 6];
+
+var match = switch (myArray) {
+    case [2, _]: "0";
+    case [_, 6]: "1";
+    case []: "2";
+    case [_, _, _]: "3";
+    case _: "4";
   }
-trace(value); // haxe
+trace(match); // 1


### PR DESCRIPTION
Somehow Struct pattern matching sample code got duplicated here after splitting done in 7de2ed9.
Original code was retrieved and reformatted.

I did not bother to create corresponding issue.
