### PR TITLE
fix compile.hxml syntax

### DIFF
--- a/content/12-target-details.md
+++ b/content/12-target-details.md
@@ -105,8 +105,8 @@ haxe --js main-javascript.js --main Main
 Another possibility is to create and run (double-click) a file called `compile.hxml`. In this example the hxml file should be in the same directory as the example class.
 
 ```hxml
---js main-javascript.js
---main Main
+-js main-javascript.js
+-main Main
 ```
 
 The output will be a main-javascript.js, which creates and adds a clickable button to the document body.


### PR DESCRIPTION
There ought only to be only "-" instead of "--" here, right? I just tried it myself and it only works with the single-dash syntax when using compile.hxml rather than from the command line. Am I missing something?