### PR TITLE
Change invalid function name

### DIFF
--- a/content/06-lf.md
+++ b/content/06-lf.md
@@ -793,7 +793,7 @@ typedef KeyValueIterator<K, V> = {
 }
 
 typedef KeyValueIterable<K, V> = {
-	function iterator() : KeyValueIterator<K, V>;
+	function keyValueIterator() : KeyValueIterator<K, V>;
 }
 ```
 


### PR DESCRIPTION
An iterable class with a KeyValueIterator must implement `keyValueIterator() : KeyValueIterator<K,V>` instead of `iterator()`