### PR TITLE
Update EReg DOTALL option supported targets

### DIFF
--- a/content/10-std.md
+++ b/content/10-std.md
@@ -295,7 +295,7 @@ The possible flags are the following:
 * `i` case insensitive matching
 * `g` global replace or split, see below
 * `m` multiline matching, `^` and `$` represent the beginning and end of a line
-* `s` the dot `.` will also match newlines **(Neko, C++, PHP, Flash and Java targets only)**
+* `s` the dot `.` will also match newlines **(not supported by C# and JavaScript targets)**
 * `u` use UTF-8 matching **(Neko and C++ targets only)**
 
 ##### Related content


### PR DESCRIPTION
I tested Haxe 3.4.7 and Haxe 4RC5. The only targets where the "s" DOTALL option do not work are C# and JavaScript.