### PR TITLE
Proofreading Effort: 02-types.md

### DIFF
--- a/content/02-types.md
+++ b/content/02-types.md
@@ -234,7 +234,7 @@ The above code will yield an instance of class `Point`, which is assigned to a v
 <!--label:types-class-inheritance-->
 #### Inheritance
 
-Classes may inherit from other classes, and is denoted by the `extends` keyword:
+Classes may inherit from other classes; this is denoted by the `extends` keyword:
 
 [code asset](assets/Point3.hx)
 
@@ -334,7 +334,7 @@ The Haxe type system provides a type which unifies with all enum types:
 <!--label:types-enum-constructor-->
 #### Enum Constructor
 
-Similar to classes and their constructors, enums can be instantiated using their constructors. However, unlike classes, enums provide multiple constructors which can accessed by through their name:
+Similar to classes and their constructors, enums can be instantiated using their constructors. However, unlike classes, enums provide multiple constructors which can accessed through their name:
 
 ```haxe
 var a = Red;
@@ -521,7 +521,7 @@ typedef User = {
 <!--label:types-structure-performance-->
 #### Impact on Performance
 
-Using structures, and by extension, [structural subtyping](type-system-structural-subtyping), has no impact on performance when compiling to [dynamic targets](define-dynamic-target). However, on [static targets](define-static-target) a dynamic lookup has to be performed which is typically slower than a static field access.
+Using structures and, by extension, [structural subtyping](type-system-structural-subtyping), has no impact on performance when compiling to [dynamic targets](define-dynamic-target). However, on [static targets](define-static-target) a dynamic lookup has to be performed which is typically slower than a static field access.
 
 
 
@@ -679,7 +679,7 @@ att.income = 0;
 <!--label:types-dynamic-access-->
 #### Dynamic access
 
-`DynamicAccess` is an [abstract type](types-abstract) for working with [anonymous structures](types-anonymous-structure) that are intended to hold collections of objects by the string key. Basically, `DynamicAccess` wraps `Reflect`std-reflection calls in a Map-like interface.
+`DynamicAccess` is an [abstract type](types-abstract) for working with [anonymous structures](types-anonymous-structure) that are intended to hold collections of objects by the string key. Basically, `DynamicAccess` wraps [`Reflect`](std-reflection) calls in a Map-like interface.
 
 [code asset](assets/DynamicAccess.hx)
 
@@ -718,7 +718,7 @@ We can derive the following from this example:
 
 * The keyword `abstract` denotes that we are declaring an abstract type.
 * `AbstractInt` is the name of the abstract type and could be anything conforming to the rules for type identifiers.
-* The **underlying type** `Int` is enclosed in parenthesis `()`.
+* The **underlying type** `Int` is enclosed in parentheses `()`.
 * The fields are enclosed in curly braces `{}`,
 * which are a constructor function `new` accepting one argument `i` of type `Int`.
 

--- a/content/02-types.md
+++ b/content/02-types.md
@@ -65,7 +65,7 @@ While every `Int` can be used where a `Float` is expected (that is, `Int` **is a
 
 For performance reasons, the Haxe Compiler does not enforce any overflow behavior. The burden of checking for overflows falls to the target platform. Here are some platform-specific notes on overflow behavior:
 
- * C++, Java, C#, Neko, Flash: 32-bit signed integers with usual overflow practices  
+* C++, Java, C#, Neko, Flash: 32-bit signed integers with usual overflow practices  
 * PHP, JS, Flash 8: No native **Int** type, loss of precision will occur if a number reaches the float limit (2<sup>52</sup>)
 
 Alternatively, the **haxe.Int32** and **haxe.Int64** classes can be used to ensure correct overflow behavior at the cost of additional computations on certain platforms.
@@ -95,8 +95,8 @@ We have already "seen" `Void` in the initial "Hello World" example:
 
 [code asset](assets/HelloWorld.hx)
 
-The function type will be explored in detail in the section [Function Type](types-function) but a quick preview helps here: The type of the function `main` in the example above is `Void->Void`, which reads as "it has no arguments and returns nothing".
-Haxe does not allow fields and variables of type `Void` and will complain if an attempt at declaring such is made:
+The function type will be explored in detail in the section [Function Type](types-function), but a quick preview helps here: the type of the function `main` in the example above is `Void->Void`, which reads as "it has no arguments and returns nothing
+Haxe does not allow fields and variables of type `Void` and will complain if such a declaration is made:
 
 ```haxe
 // Arguments and variables of type Void are not allowed
@@ -108,7 +108,7 @@ var x:Void;
 
 
 <!--label:types-nullability-->
-### Nullability
+#### Nullability
 
 > ##### Define: nullable
 >
@@ -159,9 +159,9 @@ This restriction extends to all situations where [unification](type-system-unifi
 
 > ##### Define: `Null<T>`
 >
-> On static targets the types `Null<Int>`, `Null<Float>` and `Null<Bool>` can be used to allow `null` as a value. On dynamic targets this has no effect. `Null<T>` can also be used with other types in order to document that `null` is an allowed value.
+> On static targets the types `Null<Int>`, `Null<Float>` and `Null<Bool>` can be used to allow `null` as a value. On dynamic targets this has no effect. `Null<T>` can also be used with other types in order to document that `null` is a permitted value.
 
-If a `null`-value is "hidden" in `Null<T>` or `Dynamic` and assigned to a basic type, the default value is used:
+If a `null` value is "hidden" in `Null<T>` or `Dynamic` and assigned to a basic type, the default value is used:
 
 ```haxe
 var n : Null<Int> = null;
@@ -172,9 +172,7 @@ trace(a); // 0 on static platforms
 <!--label:types-nullability-optional-arguments-->
 #### Optional Arguments and Nullability
 
-Optional arguments also have to be accounted for when considering nullability.
-
-In particular, there must be a distinction between **native** optional arguments which are not nullable and Haxe-specific optional arguments which might be. The distinction is made by using the question-mark optional argument:
+Optional arguments must be accounted for when considering nullability; a separation between **native** optional arguments which are not nullable and Haxe-specific optional arguments which may be needs to be defined. This distinction is made using the question-mark optional argument:
 
 ```haxe
 // x is a native Int (not nullable)
@@ -215,7 +213,9 @@ There is a special type in Haxe which is compatible with all classes:
 
 > ##### Define: `Class<T>`
 >
-> This type is compatible with all class types which means that all classes (not their instances) can be assigned to it. At compile-time, `Class<T>` is the common base type of all class types. However, this relation is not reflected in generated code.
+> This type is compatible with all class types which means that all classes can be assigned to it. Class instances, however, **cannot** be assigned to this type.
+>
+> At compile-time, `Class<T>` is the common base type of all class types. This relation is not reflected in generated code.
 > 
 > This type is useful when an API requires a value to be **a** class, but not a specific one. This applies to several methods of the [Haxe reflection API](std-reflection).
 
@@ -234,11 +234,11 @@ The above code will yield an instance of class `Point`, which is assigned to a v
 <!--label:types-class-inheritance-->
 #### Inheritance
 
-Classes may inherit from other classes, which in Haxe is denoted by the `extends` keyword:
+Classes may inherit from other classes, and is denoted by the `extends` keyword:
 
 [code asset](assets/Point3.hx)
 
-This relation is often described as "is-a": Any instance of class `Point3` is also an instance of `Point`. `Point` is then known as the **parent class** of `Point3`, which is a **child class** of `Point`. A class may have many child classes, but only one parent class. The term "a parent class of class X" usually refers to its direct parent class, the parent class of its parent class and so on.
+This relation is often described as "is-a": any instance of class `Point3` is also an instance of `Point`. `Point` is then known as the **parent class** of `Point3`, which is a **child class** of `Point`. A class may have many child classes, but only one parent class. The term "a parent class of class X" usually refers to its direct parent class, the parent class of its parent class and so on.
 
 The code above is very similar to the original `Point` class, with two new constructs being shown:
 
@@ -262,7 +262,7 @@ Classes can be declared with the keyword `final` to prevent them from being exte
 <!--label:types-interfaces-->
 #### Interfaces
 
-An interface can be understood as the signature of a class because it describes the public fields of a class. Interfaces do not provide implementations but pure structural information:
+An interface can be understood as the signature of a class because it describes the public fields of a class. Interfaces do not provide implementations, but rather offer purely structural information:
 
 ```haxe
 interface Printable {
@@ -271,16 +271,16 @@ interface Printable {
 ```
 The syntax is similar to classes, with the following exceptions:
 
-* `interface` keyword is used instead of `class` keyword
-* functions do not have any [expressions](expression)
-* every field must have an explicit type
+* The `interface` keyword is used instead of the `class` keyword.
+* Functions do not have any [expressions](expression).
+* Every field must have an explicit type.
 
-Interfaces, unlike [structural subtyping](type-system-structural-subtyping), describe a **static relation** between classes. A given class is only considered to be compatible to an interface if it explicitly states so:
+Interfaces, unlike [structural subtyping](type-system-structural-subtyping), describe a **static relation** between classes. A given class is only considered to be compatible to an interface if it explicitly states as much:
 
 ```haxe
 class Point implements Printable { }
 ```
-Here, the `implements` keyword denotes that `Point` has a "is-a" relationship to `Printable`, i.e. each instance of `Point` is also an instance of `Printable`. While a class may only have one parent class, it may implement multiple interfaces through multiple `implements` keywords:
+Here, the `implements` keyword denotes that `Point` has an "is-a" relationship with `Printable`, i.e. each instance of `Point` is also an instance of `Printable`. While a class may only have one parent class, it may implement multiple interfaces through multiple `implements` keywords:
 
 ```haxe
 class Point implements Printable
@@ -300,7 +300,7 @@ interface Debuggable extends Printable extends Serializable
 
 ##### since Haxe 4.0.0
 
-Analogously to classes, interfaces can also be marked with the keyword `final`, preventing them from being extended.
+Like classes, interfaces can be marked with the `final` keyword, preventing them from being extended.
 
 > ##### Trivia: Implements Syntax
 >
@@ -334,22 +334,22 @@ The Haxe type system provides a type which unifies with all enum types:
 <!--label:types-enum-constructor-->
 #### Enum Constructor
 
-Similar to classes and their constructors, enums provide a way of instantiating them by using one of their constructors. However, unlike classes, enums provide multiple constructors which can easily be used through their name:
+Similar to classes and their constructors, enums can be instantiated using their constructors. However, unlike classes, enums provide multiple constructors which can accessed by through their name:
 
 ```haxe
 var a = Red;
 var b = Green;
 var c = Rgb(255, 255, 0);
 ```
-In this code the type of variables `a`, `b` and `c` is `Color`. Variable `c` is initialized using the `Rgb` constructor with arguments.
+In this code, the type of variables `a`, `b` and `c` is `Color`. Variable `c` is initialized using the `Rgb` constructor with arguments.
 
 All enum instances can be assigned to a special type named `EnumValue`.
 
 > ##### Define: EnumValue
 >
-> EnumValue is a special type which unifies with all enum instances. It is used by the Haxe Standard Library to provide certain operations for all enum instances and can be employed in user-code accordingly in cases where an API requires **an** enum instance, but not a specific one.
+> EnumValue is a special type which unifies with all enum instances. It is used by the [Haxe Standard Library](std) to provide certain operations for all enum instances and can be employed in user-code accordingly in cases where an API requires **an** enum instance, but not a specific one.
 
-It is important to distinguish enum types and enum constructors, as this example demonstrates:
+It is important to distinguish between enum types and enum constructors, as this example demonstrates:
 
 [code asset](assets/EnumUnification.hx)
 
@@ -366,11 +366,11 @@ If the commented line is uncommented, the program does not compile because `Red`
 <!--label:types-enum-using-->
 #### Using enums
 
-Enums are a good choice if only a finite set of values should be allowed. The individual [constructors](types-enum-constructor) then represent the allowed variants and enable the compiler to check if all possible values are respected. This can be seen here:
+Enums are a good choice if only a finite set of values should be allowed. The individual [constructors](types-enum-constructor) then represent the allowed variants and enable the compiler to check if all possible values are respected:
 
 [code asset](assets/Color2.hx)
 
-After retrieving the value of `color` by assigning the return value of `getColor()` to it, a [`switch` expression](expression-switch) is used to branch depending on the value. The first three cases `Red`, `Green` and `Blue` are trivial and correspond to the constructors of `Color` that have no arguments. The final case `Rgb(r, g, b)` shows how the argument values of a constructor can be extracted: they are available as local variables within the case body expression, just as if a [`var` expression](expression-var) had been used.
+After retrieving the value of `color` by assigning the return value of `getColor()` to it, a [`switch` expression](expression-switch) is used to branch depending on the value. The first three cases, `Red`, `Green` and `Blue`, are trivial and correspond to the constructors of `Color` that have no arguments. The final case, `Rgb(r, g, b)`, shows how the argument values of a constructor can be extracted; they are available as local variables within the case body expression, just as if a [`var` expression](expression-var) had been used.
 
 Advanced information on using the `switch` expression will be explored later in the section on [pattern matching](lf-pattern-matching).
 
@@ -381,14 +381,14 @@ Advanced information on using the `switch` expression will be explored later in 
 <!--label:types-anonymous-structure-->
 ### Anonymous Structure
 
-Anonymous structures can be used to group data without explicitly creating a type. The following example creates a structure with two fields `x` and `name`, and initializes their values to `12` and `"foo"` respectively:
+Anonymous structures can be used to group data without explicitly creating a type. The following example creates a structure with two fields, `x` and `name`, and initializes their values to `12` and `"foo"` respectively:
 
 [code asset](assets/Structure.hx)
 
-The general syntactic rules follow:
+The general syntactic rules are as follows:
 
-1. A structure is enclosed in curly braces `{}` and
-2. Has a **comma-separated** list of key-value-pairs.
+1. A structure is enclosed in **curly braces** `{}` and
+2. has a **comma-separated** list of key-value pairs.
 3. A **colon** separates the key, which must be a valid [identifier](define-identifier), from the value.
 4. The value can be any Haxe expression.
 
@@ -404,7 +404,7 @@ var user = {
   ],
 };
 ```
-Fields of structures, like classes, are accessed using a **dot** (`.`) like so:
+Fields of structures, like classes, are accessed using a **dot** (`.`):
 
 ```haxe
 // get value of name, which is "Nicolas"
@@ -423,8 +423,8 @@ class Test {
   }
 }
 ```
-The error message indicates that the compiler knows the type of `point`: It is a structure with fields `x` and `y` of type `Float`. Since it has no field `z`, the access fails.
-The type of `point` is known through [type inference](type-system-type-inference), which thankfully saves us from using explicit types for local variables. However, if `point` was a field, explicit typing would be necessary:
+The error message indicates that the compiler knows the type of `point`: it is a structure with fields `x` and `y` of type `Float`. Since it has no field `z`, the access fails.
+The type of `point` is known through [type inference](type-system-type-inference), which thankfully saves us from using explicit types for local variables. If `point` was a field instead, explicit typing would be necessary:
 
 ```haxe
 class Path {
@@ -445,7 +445,7 @@ class Path {
 }
 ```
 
-You may also use [Extensions](types-structure-extensions) to "inherit" fields from other structures.
+You may also use [Extensions](types-structure-extensions) to "inherit" fields from other structures:
 
 ```haxe
 typedef Point3 = { > Point, z : Int }
@@ -459,14 +459,14 @@ It is also possible to use **JavaScript Object Notation** for structures by usin
 ```haxe
 var point = { "x" : 1, "y" : -5 };
 ```
-While any string literal is allowed, the field is only considered part of the type if it is a valid [Haxe identifier](define-identifier). Otherwise, Haxe syntax does not allow expressing access to such a field and [reflection](std-reflection) has to be employed through the use of `Reflect.field` and `Reflect.setField`.
+While any string literal is allowed, the field is only considered part of the type if it is a valid [Haxe identifier](define-identifier). Otherwise, Haxe syntax does not allow expressing access to such a field, and [reflection](std-reflection) has to be employed through the use of `Reflect.field` and `Reflect.setField` instead.
 
 
 
 <!--label:types-structure-class-notation-->
 #### Class Notation for Structure Types
 
-When defining a structure type, Haxe allows using the same syntax as described in [Class Fields](class-field). The following [typedef](type-system-typedef) declares a `Point` type with variable fields `x` and `y` of type `Int`:
+When defining a structure type, Haxe allows the use of the same syntax described in [Class Fields](class-field). The following [typedef](type-system-typedef) declares a `Point` type with variable fields `x` and `y` of type `Int`:
 
 ```haxe
 typedef Point = {
@@ -484,7 +484,7 @@ The fields of a structure may also be declared with `final`, which only allows t
 <!--label:types-structure-optional-fields-->
 #### Optional Fields
 
-Fields of a structure type can be made optional. In the standard notation, this is achieved by prefixing the field name with a `?`:
+Fields of a structure type can be made optional. In the standard notation, this is achieved by prefixing the field name with a question mark `?`:
 
 ```haxe
 typedef User = {
@@ -506,7 +506,7 @@ typedef User = {
 
 ##### since Haxe 4.0.0
 
-In Haxe 4 it is also possible to declare a structure field as optional in the **class notation** by prefixing its name with `?`:
+A structure field can be declared as optional in the **class notation** by prefixing its name with a question mark `?`:
 
 ```haxe
 typedef User = {
@@ -521,7 +521,7 @@ typedef User = {
 <!--label:types-structure-performance-->
 #### Impact on Performance
 
-Using structures and, by extension, [structural subtyping](type-system-structural-subtyping) has no impact on performance when compiling to [dynamic targets](define-dynamic-target). However, on [static targets](define-static-target) a dynamic lookup has to be performed which is typically slower than a static field access.
+Using structures, and by extension, [structural subtyping](type-system-structural-subtyping), has no impact on performance when compiling to [dynamic targets](define-dynamic-target). However, on [static targets](define-static-target) a dynamic lookup has to be performed which is typically slower than a static field access.
 
 
 
@@ -534,17 +534,17 @@ Extensions are used to express that a structure has all the fields of a given ty
 
 The greater-than operator `>` denotes that an extension of `Iterable<T>` is being created, with the additional class fields following. In this case, a read-only [property](class-field-property) `length` of type `Int` is required.
 
-In order to be compatible with `IterableWithLength<T>`, a type then must be compatible with `Iterable<T>` and also provide a read-only `length` property of type `Int`. The example assigns an `Array`, which happens to fulfill these requirements.
+In order to be compatible with `IterableWithLength<T>`, a type must be compatible with `Iterable<T>` and provide a read-only `length` property of type `Int`. The previous example assigns an `Array`, which happens to fulfill these requirements.
 
 ##### since Haxe 3.1.0
 
-It is also possible to extend multiple structures:
+Multiple structures can be extended at once:
 
 [code asset](assets/Extension2.hx)
 
 ##### since Haxe 4.0.0
 
-Haxe 4 introduces an alternative notation for extension, separating each extended structure with a `&` symbol.
+An alternative notation for extension can be used, denoted by separating each extended structure with an `&` symbol.
 
 [code asset](assets/Extension3.hx)
 
@@ -561,17 +561,18 @@ The function type, along with the [monomorph](types-monomorph), is a type which 
 
 There is a strong resemblance between the declaration of function `test` and the output of the first `$type` expression, with one subtle difference: the **function return type** appears at the end after a `->` symbol.
 
-In either notation it is obvious that the function `test` accepts one argument of type `Int` and one argument of type `String` and returns a value of type `Bool`. If a call to this function, such as `test(1, "foo")`, is made within the second `$type` expression, the Haxe typer checks if `1` can be assigned to `Int` and if `"foo"` can be assigned to `String`. The type of the call is then equal to the type of the value `test` returns, which is `Bool`.
+In either notation, it is obvious that the function `test` accepts one argument of type `Int` and one argument of type `String` and returns a value of type `Bool`. If a call to this function, such as `test(1, "foo")`, is made within the second `$type` expression, the Haxe typer checks if `1` can be assigned to `Int` and if `"foo"` can be assigned to `String`. The type of the call is then equal to the type of the value `test` returns, which is `Bool`.
 
-Note that argument names are optional in the function type. If a function type has other function types as argument or return type, parentheses can be used to group them correctly. For example, `(Int, ((Int) -> Void)) -> Void` represents a function which has one argument of type `Int` and one argument of function type `Int -> Void` and a return type `Void`.
+Note that argument names are optional in the function type. If a function type has other function types as arguments or return types, parentheses can be used to group them correctly. For example, `(Int, ((Int) -> Void)) -> Void` represents a function which has one argument of type `Int` and one argument of function type `Int -> Void` and a return type `Void`.
+
+The type of a function which takes no arguments uses `()` to represent the argument list:
 
 [code asset](assets/FunctionType2.hx)
 
-As shown in the above example, the type of a function which takes no arguments uses `()` to represent the argument list.
 
 ##### Old function type notation
 
-Before Haxe 4, the function type notation was more similar to other functional programming languages, using `->` in place of all the commas separating the argument types. The `test` function above would be typed as `Int -> String -> Bool` in this notation. `test2` would be typed as `Void -> Bool`.
+Before Haxe 4, the function type notation had more in common with other functional programming languages, using `->` in place of commas separating the argument types. The `test` function above would be typed as `Int -> String -> Bool` in this notation. `test2` would be typed as `Void -> Bool`.
 
 The older notation is still supported, although newer code should use the new notation described above since it more clearly differentiates argument types from the return type.
 
@@ -596,7 +597,7 @@ This example program calls `test` four times and prints its return value.
 
 The output shows that optional arguments which are omitted from the call have a value of `null`. This implies that the type of these arguments must admit `null` as value, which raises the question of its [nullability](types-nullability). The Haxe Compiler ensures that optional basic type arguments are nullable by inferring their type as `Null<T>` when compiling to a [static target](define-static-target).
 
-While the first three calls are intuitive, the fourth one might come as a surprise: It is indeed allowed to skip optional arguments if the supplied value is assignable to a later argument.
+While the first three calls are intuitive, the fourth one might come as a surprise; optional arguments are allowed to be skipped if the supplied value is assignable to a later argument.
 
 
 
@@ -607,9 +608,9 @@ Haxe allows default values for arguments by assigning a **constant value** to th
 
 [code asset](assets/DefaultValues.hx)
 
-This example is very similar to the one from [Optional Arguments](types-function-optional-arguments), with the only difference being that the values `12` and `"bar"` are assigned to the function arguments `i` and `s` respectively. The effect is that the default values are used instead of `null` should an argument be omitted from the call.
+This example is very similar to the example from [Optional Arguments](types-function-optional-arguments), with the only difference being that the values `12` and `"bar"` are assigned to the function arguments `i` and `s` respectively. The effect is that the default values are used instead of `null`, should an argument be omitted from the call.
 
-Default values in Haxe are not part of the type and are not replaced at the call-site (unless the function is [inlined](class-field-inline)). On some targets the compiler may still pass `null` for omitted argument values and generate code similar to this into the function:
+Default values in Haxe are not part of the type and are not replaced at the call-site unless the function is [inlined](class-field-inline). On some targets the compiler may still pass `null` for omitted argument values and generate code similar to this inside the function:
 ```haxe
 	static function test(i = 12, s = "bar") {
 		if (i == null) i = 12;
@@ -626,11 +627,11 @@ This should be considered in performance-critical code where a solution without 
 <!--label:types-dynamic-->
 ### Dynamic
 
-While Haxe has a static type system, this type system can, in effect, be turned off by using the `Dynamic` type. A **dynamic value** can be assigned to anything and anything can be assigned to it. This has several drawbacks:
+While Haxe has a static type system, it can essentially be disabled by using the `Dynamic` type. A **dynamic value** can be assigned to anything and anything can be assigned to it. This has several drawbacks:
 
 * The compiler can no longer type-check assignments, function calls and other constructs where specific types are expected.
 * Certain optimizations, in particular when compiling to static targets, can no longer be employed.
-* Some common errors, e.g. a typo in field access, cannot be caught at compile-time and likely cause an error at runtime.
+* Some common errors such as typos in field accesses cannot be caught at compile-time and likely cause errors at runtime.
 * [Dead Code Elimination](cr-dce) cannot detect used fields if they are used through `Dynamic`.
 
 It is very easy to come up with examples where the usage of `Dynamic` can cause problems at runtime. Consider compiling the following two lines to a static target:
@@ -642,17 +643,17 @@ d.foo;
 
 Trying to run a compiled program in the Flash Player yields an error `Property foo not found on Number and there is no default value`. Without `Dynamic`, this would have been detected at compile-time.
 
-> ##### Trivia: Dynamic Inference before Haxe 3
->
-> The Haxe 3 compiler never infers a type to `Dynamic`, so users must be explicit about it. Previous Haxe versions used to infer arrays of mixed types, e.g. `[1, true, "foo"]`, as `Array<Dynamic>`. We found that this behavior introduced too many type problems and thus removed it for Haxe 3.
-
-Use of `Dynamic` should be minimized as there are better options in many situations but sometimes it is just practical to use it. Parts of the Haxe [Reflection](std-reflection) API use it and it is sometimes the best option when dealing with custom data structures that are not known at compile-time.
+Use of `Dynamic` should be minimized as there are often better options available. However, it is occasionally the practical solution; parts of the Haxe [Reflection](std-reflection) API make use of it. Additionally, using `Dynamic` can be the best choice to handle custom data structures that are not known at compile-time.
 
 `Dynamic` behaves in a special way when being [unified](type-system-unification) with a [monomorph](types-monomorph). Monomorphs are never bound to `Dynamic` which can have surprising results in examples such as this:
 
 [code asset](assets/DynamicInferenceIssue.hx)
 
 Although the return type of `Json.parse` is `Dynamic`, the type of local variable `json` is not bound to it and remains a monomorph. It is then inferred as an [anonymous structure](types-anonymous-structure) upon the `json.length` field access, which causes the following `json[0]` array access to fail. In order to avoid this, the variable `json` can be explicitly typed as `Dynamic` by using `var json:Dynamic`.
+
+> ##### Trivia: Dynamic Inference before Haxe 3
+>
+> The Haxe 3 compiler never infers a type to `Dynamic`, so users must be explicit about it. Previous Haxe versions used to infer arrays of mixed types, e.g. `[1, true, "foo"]`, as `Array<Dynamic>`. We found that this behavior introduced too many type problems and thus removed it for Haxe 3.
 
 > ##### Trivia: Dynamic in the Standard Library
 >
@@ -678,7 +679,7 @@ att.income = 0;
 <!--label:types-dynamic-access-->
 #### Dynamic access
 
-`DynamicAccess` is an [abstract type](types-abstract) for working with [anonymous structures](types-anonymous-structure) that are intended to hold collections of objects by the string key. Basically `DynamicAccess` wraps `Reflect`std-reflection calls in a Map-like interface.
+`DynamicAccess` is an [abstract type](types-abstract) for working with [anonymous structures](types-anonymous-structure) that are intended to hold collections of objects by the string key. Basically, `DynamicAccess` wraps `Reflect`std-reflection calls in a Map-like interface.
 
 [code asset](assets/DynamicAccess.hx)
 
@@ -687,8 +688,8 @@ att.income = 0;
 <!--label:types-dynamic-any-->
 #### Any type
 
-`Any` is a type that is compatible with any other in both ways. 
-It serves one purpose - to hold values of any type, but to actually use those values, explicit casting is required. That way the code doesn't suddenly become dynamically typed and we keep all the static typing goodness, like advanced type system features and optimizations.
+`Any` is a type that is compatible with any other type in both directions. 
+It serves one purpose - to hold values of any type. Explicit casting is required to use these values in order to guarantee that the code does not suddenly become dynamically typed. This restriction maintains Haxe's static typing, and allows for the continued use of advanced type system features and optimizations associated with the type system.
 
 The implementation is quite simple:
 
@@ -696,11 +697,11 @@ The implementation is quite simple:
 abstract Any(Dynamic) from Dynamic to Dynamic {}
 ```
 
-This type doesn't make any assumptions about what the value actually is and whether it supports fields or any operations - this is up to the user.
+The 'Any' type does not make assumptions about what the value actually is or whether it supports fields or operations - this is up to the user to handle.
 
 [code asset](assets/Any.hx)
 
-It's a more type-safe alternative to `Dynamic`, because it doesn't support field access or operators and it's bound to monomorphs. So, to work with the actual value, it needs to be explicitly promoted to another type.
+`Any` is a more type-safe alternative to `Dynamic` because it doesn't support field access or operators and is bound to monomorphs. To work with the actual value, it needs to be explicitly promoted to another type.
 
 
 
@@ -716,22 +717,22 @@ An abstract type is a type which is actually a different type at run-time. It is
 We can derive the following from this example:
 
 * The keyword `abstract` denotes that we are declaring an abstract type.
-* `AbstractInt` is the name of the abstract and could be anything conforming to the rules for type identifiers.
-* Enclosed in parenthesis `()` is the **underlying type** `Int`.
-* Enclosed in curly braces `{}` are the fields,
+* `AbstractInt` is the name of the abstract type and could be anything conforming to the rules for type identifiers.
+* The **underlying type** `Int` is enclosed in parenthesis `()`.
+* The fields are enclosed in curly braces `{}`,
 * which are a constructor function `new` accepting one argument `i` of type `Int`.
 
 > ##### Define: Underlying Type
 >
 > The underlying type of an abstract is the type which is used to represent said abstract at runtime. It is usually a concrete (i.e. non-abstract) type but could be another abstract type as well.
 
-The syntax is reminiscent of classes and the semantics are indeed similar. In fact, everything in the "body" of an abstract (that is everything after the opening curly brace) is parsed as class fields. Abstracts may have [method](class-field-method) fields and non-[physical](define-physical-field) [property](class-field-property) fields.
+The syntax is reminiscent of classes and the semantics are indeed similar. In fact, everything in the "body" of an abstract (everything after the opening curly brace) is parsed as class fields. Abstracts may have [method](class-field-method) fields and non-[physical](define-physical-field) [property](class-field-property) fields.
 
 Furthermore, abstracts can be instantiated and used just like classes:
 
 [code asset](assets/MyAbstract.hx#L7-L12)
 
-As mentioned before, abstracts are a compile-time feature, so it is interesting to see what the above actually generates. A suitable target for this is JavaScript, which tends to generate concise and clean code. Compiling the above (using `haxe --main MyAbstract --js myabstract.js`) shows this JavaScript code:
+As mentioned before, abstracts are a compile-time feature, so it is interesting to see what the above actually generates. A suitable target for this is JavaScript, which tends to generate concise and clean code. Compiling the above using `haxe --main MyAbstract --js myabstract.js` shows this JavaScript code:
 
 ```js
 var a = 12;
@@ -739,7 +740,7 @@ console.log(a);
 ```
 The abstract type `Abstract` completely disappeared from the output and all that is left is a value of its underlying type, `Int`. This is because the constructor of `Abstract` is inlined - something we shall learn about later in the section [Inline](class-field-inline) - and its inlined expression assigns a value to `this`. This might be surprising when thinking in terms of classes. However, it is precisely what we want to express in the context of abstracts. Any **inlined member method** of an abstract can assign to `this` and thus modify the "internal value".
 
-A good question at this point is "What happens if a member function is not declared inline" because the code obviously has to go somewhere. Haxe creates a private class, known to be the **implementation class**, which has all the abstract member functions as static functions accepting an additional first argument `this` of the underlying type.
+One problem may be apparent - what happens if a member function is not declared inline? The code obviously must be placed somewhere! Haxe handles this by creating a private class, known as the **implementation class**, which contains all the abstract member functions as static functions accepting an additional first argument `this` of the underlying type.
 
 > ##### Trivia: Basic Types and abstracts
 >
@@ -757,19 +758,19 @@ The following code example shows an example of **direct** casting:
 
 [code asset](assets/ImplicitCastDirect.hx)
 
-We declare `MyAbstract` as being `from Int` and `to Int`, meaning it can be assigned from `Int` and assigned to `Int`. This is shown in lines 9 and 10, where we first assign the `Int` `12` to variable `a` of type `MyAbstract` (this works due to the `from Int` declaration) and then that abstract back to variable `b` of type `Int` (this works due to the `to Int` declaration).
+We declare `MyAbstract` as being `from Int` and `to Int`, appropriately meaning it can be assigned from `Int` and assigned to `Int`. This is shown in lines 9 and 10, where we first assign the `Int` `12` to variable `a` of type `MyAbstract` (this works due to the `from Int` declaration) and then that abstract back to variable `b` of type `Int` (this works due to the `to Int` declaration).
 
 Class field casts have the same semantics, but are defined completely differently:
 
 [code asset](assets/ImplicitCastField.hx)
 
-By adding `@:from` to a static function, that function qualifies as implicit cast function from its argument type to the abstract. These functions must return a value of the abstract type. They must also be declared `static`.
+By adding `@:from` to a static function, that function qualifies as an implicit cast function from its argument type to the abstract. These functions must return a value of the abstract type. They must also be declared `static`.
 
 Similarly, adding `@:to` to a function qualifies it as implicit cast function from the abstract to its return type.
 
-In the example the method `fromString` allows the assignment of value `"3"` to variable `a` of type `MyAbstract` while the method `toArray` allows assigning that abstract to variable `b` of type `Array<Int>`.
+In the previous example, the method `fromString` allows the assignment of value `"3"` to variable `a` of type `MyAbstract` while the method `toArray` allows assigning that abstract to variable `b` of type `Array<Int>`.
 
-When using this kind of cast, calls to the cast-functions are inserted where required. This becomes obvious when looking at the JavaScript output:
+When using this kind of cast, calls to the cast functions are inserted where required. This becomes obvious when looking at the JavaScript output:
 
 ```js
 var a = _ImplicitCastField.MyAbstract_Impl_.fromString("3");
@@ -781,12 +782,12 @@ This can be further optimized by [inlining](class-field-inline) both cast functi
 var a = Std.parseInt("3");
 var b = [a];
 ```
-The **selection algorithm** when assigning a type `A` to a type `B` with at least one of them being an abstract is simple:
+The **selection algorithm** when assigning a type `A` to a type `B` where at least one is an abstract is simple:
 
 1. If `A` is not an abstract, go to 3.
-2. If `A` defines a **to**-conversions that admits `B`, go to 6.
+2. If `A` defines a **to**-conversion that admits `B`, go to 6.
 3. If `B` is not an abstract, go to 5.
-4. If `B` defines a **from**-conversions that admits `A`, go to 6.
+4. If `B` defines a **from**-conversion that admits `A`, go to 6.
 5. Stop, unification fails.
 6. Stop, unification succeeds.
 
@@ -798,7 +799,7 @@ By design, implicit casts are **not transitive**, as the following example shows
 
 [code asset](assets/ImplicitTransitiveCast.hx)
 
-While the individual casts from `A` to `B` and from `B` to `C` are allowed, a transitive cast from `A` to `C` is not. This is to avoid ambiguous cast-paths and retain a simple selection algorithm.
+While the individual casts from `A` to `B` and from `B` to `C` are allowed, a transitive cast from `A` to `C` is not. This is to avoid ambiguous cast paths and retain a simple selection algorithm.
 
 
 
@@ -809,7 +810,7 @@ Abstracts allow overloading of unary and binary operators by adding the `@:op` m
 
 [code asset](assets/AbstractOperatorOverload.hx)
 
-By defining `@:op(A * B)`, the function `repeat` serves as operator method for the multiplication `*` operator when the type of the left value is `MyAbstract` and the type of the right value is `Int`. The usage is shown in line 17, which turns into this when compiled to JavaScript:
+By defining `@:op(A * B)`, the function `repeat` serves as the operator method for the multiplication `*` operator when the type of the left value is `MyAbstract` and the type of the right value is `Int`. The usage is shown in line 17, which turns into the following code when compiled to JavaScript:
 
 ```js
 console.log(_AbstractOperatorOverload.
@@ -817,9 +818,11 @@ console.log(_AbstractOperatorOverload.
 ```
 Similar to [implicit casts with class fields](types-abstract-implicit-casts), a call to the overload method is inserted where required.
 
-The example `repeat` function is not commutative: While `MyAbstract * Int` works, `Int * MyAbstract` does not. If this should be allowed as well, the `@:commutative` metadata can be added. If it should work **only** for `Int * MyAbstract`, but not for `MyAbstract * Int`, the overload method can be made static, accepting `Int` and `MyAbstract` as first and second type respectively.
+The example `repeat` function is not commutative: while `MyAbstract * Int` works, `Int * MyAbstract` does not. The `@:commutative` metadata can be attached to the function to force it to accept the types in either order. 
 
-Overloading unary operators is analogous:
+If the function should work **only** for `Int * MyAbstract`, but not for `MyAbstract * Int`, the overload method can be made static, accepting `Int` and `MyAbstract` as the first and second types respectively.
+
+Overloading unary operators is similar:
 
 [code asset](assets/AbstractUnopOverload.hx)
 
@@ -827,7 +830,7 @@ Both binary and unary operator overloads can return any type.
 
 ##### since Haxe 4.0.0
 
-In addition to binary and unary operators, the `@:op` syntax can be used to overload field access and array access on abstracts.
+The `@:op` syntax can be used to overload field access and array access on abstracts:
 
 * `@:op([])` on a function with one argument overloads array read accces.
 * `@:op([])` on a function with two arguments overloads array write accces, with the first argument being the index and the second one being the written value.
@@ -838,7 +841,7 @@ In addition to binary and unary operators, the `@:op` syntax can be used to over
 
 ##### Exposing underlying type operations
 
-It is also possible to omit the method body of a `@:op` function, but only if the underlying type of the abstract allows the operation in question and if the resulting type can be assigned back to the abstract.
+The method body of an `@:op` function can be omitted, but only if the underlying type of the abstract allows the operation in question and the resulting type can be assigned back to the abstract.
 
 [code asset](assets/AbstractExposeTypeOperations.hx)
 
@@ -847,7 +850,7 @@ It is also possible to omit the method body of a `@:op` function, but only if th
 <!--label:types-abstract-array-access-->
 #### Array Access
 
-Array access describes the particular syntax traditionally used to access the value in an array at a certain offset. This is usually only allowed with arguments of type `Int`. Nevertheless, with abstracts, it is possible to define custom array access methods. The [Haxe Standard Library](std) uses this in its `Map` type, where the following two methods can be found:
+Array access describes the particular syntax traditionally used to access a value in an array at a certain offset. This is usually only allowed with arguments of type `Int`. Using abstracts, however, it is possible to define custom array access methods. The [Haxe Standard Library](std) uses this in its `Map` type, where the following two methods can be found:
 
 ```haxe
 @:arrayAccess
@@ -865,11 +868,11 @@ There are two kinds of array access methods:
 * If an `@:arrayAccess` method accepts one argument, it is a getter.
 * If an `@:arrayAccess` method accepts two arguments, it is a setter.
 
-The methods `get` and `arrayWrite` seen above then allow the following usage:
+The methods `get` and `arrayWrite` seen above then allow for the following usage:
 
 [code asset](assets/AbstractArrayAccess.hx)
 
-At this point it should not be surprising to see that calls to the array access fields are inserted in the output:
+At this point, it should not be surprising to see that calls to the array access fields are inserted into the output:
 
 ```js
 map.set("foo",1);
@@ -878,11 +881,11 @@ console.log(map.get("foo")); // 1
 
 ##### Order of array access resolving
 
-Due to a bug in Haxe versions before 3.2 the order of checked `:arrayAccess` fields was undefined. This was fixed for Haxe 3.2 so that the fields are now consistently checked from top to bottom:
+Due to a bug in Haxe versions before 3.2, the order of checked `@:arrayAccess` fields was undefined. This was fixed for Haxe 3.2 so that the fields are now consistently checked from top to bottom:
 
 [code asset](assets/AbstractArrayAccessOrder.hx)
 
-The array access `a[0]` is resolved to the `getInt1` field, leading to lower case `f` being returned. The result might be different in Haxe versions before 3.2.
+The array access `a[0]` is resolved to the `getInt1` field, leading to the lower case `f` being returned. The result might be different in Haxe versions before 3.2.
 
 Fields which are defined earlier take priority even if they require an [implicit cast](types-abstract-implicit-casts).
 
@@ -893,7 +896,7 @@ Fields which are defined earlier take priority even if they require an [implicit
 
 ##### since Haxe 3.1.0
 
-By adding the `:enum` metadata to an abstract definition, that abstract can be used to define finite value sets:
+By adding the `@:enum` metadata to an abstract definition, that abstract can be used to define finite value sets:
 
 [code asset](assets/AbstractEnum.hx)
 
@@ -922,7 +925,7 @@ This is similar to accessing [variables declared as inline](class-field-inline),
 
 ##### since Haxe 4.0.0
 
-Since Haxe 4, it is possible to declare enum abstracts without using the `:enum` metadata, instead using the more natural syntax `enum abstract`. Additionally, if the underlying type is `String` or `Int`, the values for the enum cases can be omitted and are deduced by the compiler:
+Enum abstracts can be declared without using the `@:enum` metadata, instead using the more natural syntax `enum abstract`. Additionally, if the underlying type is `String` or `Int`, the values for the enum cases can be omitted and are deduced by the compiler:
 
 * For `Int` abstracts, the deduced values increment the last user-defined value or start at zero if no value was declared yet.
 * For `String` abstracts, the deduced value is the identifier of the enum case.
@@ -936,13 +939,13 @@ Since Haxe 4, it is possible to declare enum abstracts without using the `:enum`
 
 ##### since Haxe 3.1.0
 
-When wrapping an underlying type, it is sometimes desirable to "keep" parts of its functionality. Because writing forwarding functions by hand is cumbersome, Haxe allows adding the `:forward` metadata to an abstract type:
+When wrapping an underlying type, it is sometimes desirable to "keep" parts of its functionality. Because writing forwarding functions by hand is cumbersome, Haxe allows adding the `@:forward` metadata to an abstract type:
 
 [code asset](assets/AbstractExpose.hx)
 
-The `MyArray` abstract in this example wraps `Array`. Its `:forward` metadata has two arguments which correspond to the field names to be forwarded to the underlying type. In this example, the `main` method instantiates `MyArray` and accesses its `push` and `pop` methods. The commented line demonstrates that the `length` field is not available.
+The `MyArray` abstract in this example wraps `Array`. Its `@:forward` metadata has two arguments which correspond to the field names to be forwarded to the underlying type. In this example, the `main` method instantiates `MyArray` and accesses its `push` and `pop` methods. The commented line demonstrates that the `length` field is not available.
 
-As usual we can look at the JavaScript output to see how the code is being generated:
+As usual, we can look at the JavaScript output to see how the code is being generated:
 
 ```js
 Main.main = function() {
@@ -952,35 +955,31 @@ Main.main = function() {
 };
 ```
 
-It is also possible to use `:forward` without any arguments in order to forward all fields. Of course, the Haxe Compiler still ensures that the field actually exists on the underlying type.
+`@:forward` can be utilized without any arguments in order to forward all fields. Of course, the Haxe Compiler still ensures that the field actually exists on the underlying type.
 
 > ##### Trivia: Implemented as macro
 >
-> Both the `:enum` and `:forward` functionality were originally implemented using [build macros](macro-type-building). While this worked nicely in non-macro code, it caused issues if these features were used from within macros. The implementation was subsequently moved to the compiler.
+> Both the `@:enum` and `@:forward` functionality were originally implemented using [build macros](macro-type-building). While this worked nicely in non-macro code, it caused issues if these features were used from within macros. The implementation was subsequently moved to the compiler.
 
 
 
 <!--label:types-abstract-core-type-->
 #### Core-type abstracts
 
-The Haxe Standard Library defines a set of basic types as core-type abstracts. They are identified by the `:coreType` metadata and the lack of an underlying type declaration. These abstracts can still be understood to represent a different type. Still, that type is native to the Haxe target. 
+The [Haxe Standard Library](std) defines a set of basic types as core-type abstracts. They are identified by the `@:coreType` metadata and the lack of an underlying type declaration. These abstracts can still be understood to represent a different type. Still, that type is native to the Haxe target. 
 
 Introducing custom core-type abstracts is rarely necessary in user code as it requires the Haxe target to be able to make sense of it. However, there could be interesting use-cases for authors of macros and new Haxe targets.
 
 In contrast to opaque abstracts, core-type abstracts have the following properties:
 
 * They have no underlying type.
-* They are considered nullable unless they are annotated with `:notNull` metadata.
+* They are considered nullable unless they are annotated with `@:notNull` metadata.
 * They are allowed to declare [array access](types-abstract-array-access) functions without expressions.
 * [Operator overloading fields](types-abstract-operator-overloading) that have no expression are not forced to adhere to the Haxe type semantics.
-
-
 
 
 
 <!--label:types-monomorph-->
 ### Monomorph
 
-A monomorph is a type which may, through [unification](type-system-unification), morph into a different type later. We shall see details about this type when talking about [type inference](type-system-type-inference).
-
-
+A monomorph is a type which may, through [unification](type-system-unification), morph into a different type later. Further details about this type are explained in the section on [type inference](type-system-type-inference).

--- a/content/02-types.md
+++ b/content/02-types.md
@@ -322,7 +322,7 @@ Semantically, this enum describes a color which is either red, green, blue or a 
 * The keyword `enum` denotes that we are declaring an enum.
 * `Color` is the name of the enum and could be anything conforming to the rules for [type identifiers](define-identifier).
 * Enclosed in curly braces `{}` are the **enum constructors**,
-* which are `Red`, `Green` and `Blue` taking no arguments,
+* which are `Red`, `Green`, and `Blue` taking no arguments,
 * as well as `Rgb` taking three `Int` arguments named `r`, `g` and `b`.
 
 The Haxe type system provides a type which unifies with all enum types:
@@ -370,7 +370,7 @@ Enums are a good choice if only a finite set of values should be allowed. The in
 
 [code asset](assets/Color2.hx)
 
-After retrieving the value of `color` by assigning the return value of `getColor()` to it, a [`switch` expression](expression-switch) is used to branch depending on the value. The first three cases, `Red`, `Green` and `Blue`, are trivial and correspond to the constructors of `Color` that have no arguments. The final case, `Rgb(r, g, b)`, shows how the argument values of a constructor can be extracted; they are available as local variables within the case body expression, just as if a [`var` expression](expression-var) had been used.
+After retrieving the value of `color` by assigning the return value of `getColor()` to it, a [`switch` expression](expression-switch) is used to branch depending on the value. The first three cases, `Red`, `Green`, and `Blue`, are trivial and correspond to the constructors of `Color` that have no arguments. The final case, `Rgb(r, g, b)`, shows how the argument values of a constructor can be extracted; they are available as local variables within the case body expression, just as if a [`var` expression](expression-var) had been used.
 
 Advanced information on using the `switch` expression will be explored later in the section on [pattern matching](lf-pattern-matching).
 
@@ -597,7 +597,7 @@ This example program calls `test` four times and prints its return value.
 
 The output shows that optional arguments which are omitted from the call have a value of `null`. This implies that the type of these arguments must admit `null` as value, which raises the question of its [nullability](types-nullability). The Haxe Compiler ensures that optional basic type arguments are nullable by inferring their type as `Null<T>` when compiling to a [static target](define-static-target).
 
-While the first three calls are intuitive, the fourth one might come as a surprise; optional arguments are allowed to be skipped if the supplied value is assignable to a later argument.
+While the first three calls are intuitive, the fourth one might come as a surprise; optional arguments can be skipped if the supplied value is assignable to a later argument.
 
 
 

--- a/content/02-types.md
+++ b/content/02-types.md
@@ -95,7 +95,7 @@ We have already "seen" `Void` in the initial "Hello World" example:
 
 [code asset](assets/HelloWorld.hx)
 
-The function type will be explored in detail in the section [Function Type](types-function), but a quick preview helps here: the type of the function `main` in the example above is `Void->Void`, which reads as "it has no arguments and returns nothing
+The function type will be explored in detail in the section [Function Type](types-function), but a quick preview helps here: the type of the function `main` in the example above is `Void->Void`, which reads as "it has no arguments and returns nothing."
 Haxe does not allow fields and variables of type `Void` and will complain if such a declaration is made:
 
 ```haxe

--- a/content/02-types.md
+++ b/content/02-types.md
@@ -850,7 +850,7 @@ The method body of an `@:op` function can be omitted, but only if the underlying
 <!--label:types-abstract-array-access-->
 #### Array Access
 
-Array access describes the particular syntax traditionally used to access a value in an array at a certain offset. This is usually only allowed with arguments of type `Int`. Using abstracts, however, it is possible to define custom array access methods. The [Haxe Standard Library](std) uses this in its `Map` type, where the following two methods can be found:
+Array access describes the particular syntax traditionally used to access a value in an array at a certain offset. This is usually only allowed with arguments of type `Int`. Using abstracts, however, makes it possible to define custom array access methods. The [Haxe Standard Library](std) uses this in its `Map` type, where the following two methods can be found:
 
 ```haxe
 @:arrayAccess


### PR DESCRIPTION
Ongoing from #445 

Includes a ton of general grammatical adjustments and punctuation corrections. There's a lot, so make sure to check for any errors that I may have introduced.

I'm requesting feedback on two aspects of these changes:
- Should instances of metadata be displayed as "@:metadata" or ":metadata"? I've seen both used, and I'm unsure of why this is the case. For now, I defaulted everything to use the @ prefix since it's actually used in code, but I may be missing the point.
- Should instances of the word "abstract/abstracts" be replaced with "abstract type/abstract types"? I am not certain if the first is completely appropriate, but I have no strong feelings either way.

My overall plan after going through this page has changed slightly:
- I plan to move all Trivia boxes down to the bottom of any respective section they reside in (documentation first, fun stuff second; if a trivia box is holding important information it shouldn't be trivia)
- I will add links, but only for keywords and phrases that should have already been linked (Haxe Standard Library should link to the std page, for instance)

If you have any questions or concerns about how I'm editing the documentation, please let me know! Thanks.