### PR TITLE
Remove AS3 target mentions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,6 @@ matrix:
     - env: TARGET=swf
       haxe: development
 
-    - env: TARGET=as3
-      haxe: 4.0.2
-
     - env: TARGET=interp
       haxe: development
 

--- a/content/06-lf.md
+++ b/content/06-lf.md
@@ -221,13 +221,12 @@ An exhaustive list of all built-in defines can be obtained by invoking the Haxe 
 
 Depending on the current target, at least one of the following flags will be defined. Note that they are the same as the [argument provided to the compiler to specify the output](compiler-usage).
 
-* `as3` Defined when generating ActionScript 3 code.
 * `cpp` Defined when generating C++ code or a cppia script.
 * `cppia` Defined when generating a cppia script.
 * `cs` Defined when generating C# code.
 * `eval` Defined when running the code with `--interp`, or when running in a macro context.
 * `hl` Defined when generating HashLink code.
-* `java` Defined when generating Java code.
+* `java` Defined when generating Java or JVM code.
 * `js` Defined when generating JavaScript code.
 * `lua` Defined when generating Lua code.
 * `neko` Defined when generating a Neko binary.
@@ -825,7 +824,7 @@ By default, trailing optional arguments are bound to their default values and do
 > ##### Trivia: Callback
 >
 > Prior to Haxe 3, Haxe used to know a `callback`-keyword which could be called with a function argument followed by any number of binding arguments. The name originated from a common usage were a callback-function is created with the this-object being bound.
-> 
+>
 > Callback would allow binding of arguments only from left to right as there was no support for the underscore `_`. The choice to use an underscore was controversial and several other suggestions were made, none of which were considered superior. After all, the underscore `_` at least looks like it's saying "fill value in here", which nicely describes its semantics.
 
 
@@ -911,13 +910,13 @@ The `@:access(MyClass.foo)` annotation effectively subverts the visibility of th
 > ##### Trivia: On the choice of metadata
 >
 > The access control language feature uses the Haxe metadata syntax instead of additional language-specific syntax. There are several reasons for that:
-> 
-> 
+>
+>
 > * Additional syntax often adds complexity to the language parsing, and also adds (too) many keywords.
 > * Additional syntax requires additional learning by the language user, whereas metadata syntax is something that is already known.
 > * The metadata syntax is flexible enough to allow extension of this feature.
 > * The metadata can be accessed/generated/modified by Haxe macros.
-> 
+>
 > Of course, the main drawback of using metadata syntax is that you get no error report in case you misspell either the metadata key (@:access for instance) or the class/package name. However, with this feature you will get an error when you try to access a private field that you are not allowed to, therefore there is no possibility for silent errors.
 
 ##### since Haxe 3.1.0

--- a/content/07-compiler-usage.md
+++ b/content/07-compiler-usage.md
@@ -10,7 +10,7 @@ The Haxe Compiler is typically invoked from command line with several arguments 
 
 To answer the first question, it is usually sufficient to provide a class path via the `-p <path>` argument, along with the main class to be compiled via the `-m <dot_path>` argument. The Haxe Compiler then resolves the main class file and begins compilation.
 
-The second question usually comes down to providing an argument specifying the desired target. Each Haxe target has a dedicated command line switch, such as `--js <file_name>` for JavaScript and `--php <directory>` for PHP. Depending on the nature of the target, the argument value is either a directory path (for `--as3`, `--php`, `--cpp`, `--cs`, and `--java`) or a file name.
+The second question usually comes down to providing an argument specifying the desired target. Each Haxe target has a dedicated command line switch, such as `--js <file_name>` for JavaScript and `--php <directory>` for PHP. Depending on the nature of the target, the argument value is either a directory path (for `--php`, `--cpp`, `--cs`, and `--java`) or a file name.
 
 ##### Common arguments
 
@@ -24,13 +24,12 @@ The second question usually comes down to providing an argument specifying the d
 **Output:**
 
 * `--js <file_name.js>` Generate [JavaScript](target-javascript) source code in specified file.
-* `--as3 directory` Generate ActionScript 3 source code in specified directory.
 * `--swf <file_name.swf>` Generate the specified file as [Flash](target-flash) `.swf`.
 * `--neko <file_name.n>` Generate [Neko](target-neko) binary as specified file.
 * `--php <directory>` Generate [PHP](target-php) source code in specified directory. Use `-D php7` for PHP7 source code.
 * `--cpp <directory>` Generate [C++](target-cpp) source code in specified directory and compiles it using native C++ compiler.
 * `--cs <directory>` Generate [C#](target-cs) source code in specified directory.
-* `--java <directory>` Generate [Java](target-java) source code in specified directory and compiles it using the Java Compiler.
+* `--java <directory>` Generate [Java](target-java) source code in specified directory and compiles it using the Java Compiler. Add `-D jvm` to generate JVM byte code directly bypassing Java compilation step.
 * `--python <file_name.py>` Generate [Python](target-python) source code in the specified file.
 * `--lua <file_name.lua>` Generate [Lua](target-python) source code in the specified file.
 * `--hl <file_name.hl>` Generate [HashLink](target-hl) byte code in specified file.
@@ -50,7 +49,7 @@ The second question usually comes down to providing an argument specifying the d
 * `--cmd <command>` Run the specified shell command after a successful compilation.
 * `--no-traces` Don't compile trace calls in the program.
 * `--gen-hx-classes` Generate hx headers for all input classes.
-* `--display` Display code tips to provide [completion information for IDEs and editors](cr-completion-overview). 
+* `--display` Display code tips to provide [completion information for IDEs and editors](cr-completion-overview).
 * `--times` Measure compilation times.
 * `--no-inline` Disable [inlining](class-field-inline).
 * `--no-opt` Disable code optimizations.
@@ -79,7 +78,7 @@ The second question usually comes down to providing an argument specifying the d
 >
 > Use `--cmd` to run the specified command after a successful compilation. It can be used to run (testing) tools or to directly run the build, e.g. `--cmd java -jar bin/Main.jar` (for Java), `--cmd node main.js` (for Node.js) or `--cmd neko Main.n` (for Neko) etc.
 
-##### Global compiler configuration macros: 
+##### Global compiler configuration macros:
 
 In order to include single modules, their paths can be listed directly on command line or in hxml: `haxe ... ModuleName pack.ModuleName`. For more specific includes or excludes, use these [initialization macros](macro-initialization):
 
@@ -140,12 +139,12 @@ This example has a configuration which compiles three different classes into the
 --js bin/homepage.js
 --main website.HomePage
 
---next  
+--next
 
 --js bin/gallery.js
 --main website.GalleryPage
 
---next  
+--next
 
 --js bin/contact.js
 --main website.ContactPage
@@ -153,17 +152,17 @@ This example has a configuration which compiles three different classes into the
 
 ##### Comments inside hxml
 
-Inside .hxml files use a hash (i.e. `#`) to comment out the rest of the line. 
+Inside .hxml files use a hash (i.e. `#`) to comment out the rest of the line.
 
 **Calling build configurations inside HXML:**
 
 It is possible to create a configuration that looks like this:
 
 ```hxml
-build-server.hxml  
---next  
-build-website.hxml  
---next  
+build-server.hxml
+--next
+build-website.hxml
+--next
 build-game.hxml
 ```
 
@@ -174,7 +173,7 @@ build-game.hxml
 
 Starting from Haxe 3.0, you can get the list of supported [compiler flags](lf-condition-compilation) by running `haxe --help-defines`
 
-Flag | Argument | Description | Platforms 
+Flag | Argument | Description | Platforms
  --- | --- | --- | ---
 <!--include:generated/defines.md-->
 

--- a/content/generated/defines.md
+++ b/content/generated/defines.md
@@ -1,7 +1,6 @@
 `absolute_path` |  | Print absolute file path in trace output. | all
 `advanced-telemetry` |  | Allow the SWF to be measured with Monocle tool. | flash
 `annotate_source` |  | Add additional comments to generated source code. | cpp
-`as3` |  | Defined when outputting flash9 as3 source code. | all
 `check_xml_proxy` |  | Check the used fields of the XML proxy. | all
 `core_api` |  | Defined in the core API context. | all
 `core_api_serialize` |  | Mark some generated core API classes with the `Serializable` attribute on C#. | cs

--- a/tests/RunTravis.hx
+++ b/tests/RunTravis.hx
@@ -9,7 +9,6 @@ using StringTools;
 abstract Target(String) from String to String
 {
 	var Swf = "swf";
-	var As3 = "as3";
 	var Js = "js";
 	var Neko = "neko";
 	var Cpp = "cpp";


### PR DESCRIPTION
And add some JVM.
Also, i hope spaces at the end of lines can be removed in `Column | Column ` and `> `, at least github markdown support this, so people like me don't need to disable `trim whitespace on file save` =)