### PR TITLE
Update 12-target-details.md

### DIFF
--- a/content/12-target-details.md
+++ b/content/12-target-details.md
@@ -735,7 +735,7 @@ export HXCPP_VERBOSE=
 Or, on Windows:
 
 ```
-setenv HXCPP_VERBOSE
+set HXCPP_VERBOSE=1
 ```
 
 If you are running Haxe though an IDE, some care must be taken with environment variables since the variables may be read once from the environment in which the IDE was started, rather than changing when the variables are changed on the system.


### PR DESCRIPTION
Fixed setting environment variable on windows (since "setenv" returns an error and it's not possible to set an environment variable on windows without specifying a value)