### PR TITLE
HashLink -> lib requirement in compile.hxml added

### DIFF
--- a/content/12-target-details.md
+++ b/content/12-target-details.md
@@ -2306,6 +2306,7 @@ Another possibility is to create and run (double-click) a file called `compile.h
 
 ```hxml
 --hl hello.hl
+--lib hlsdl # SDL support (Linux, Windows, MacOS), use '--lib hldx' for DirectX support (only Windows)
 --main Main
 ```
 


### PR DESCRIPTION
"--lib hlsdl" or "--lib hldx" in compile.hxml are required, otherwise the execution by Hashlink will not start. Information is in the Readme.md but not in the doc.