### PR TITLE
Fix assets/MyAbstract.hx class's name to match module name

### DIFF
--- a/assets/MyAbstract.hx
+++ b/assets/MyAbstract.hx
@@ -4,7 +4,7 @@ abstract AbstractInt(Int) {
   }
 }
 
-class Main {
+class MyAbstract {
   static public function main() {
     var a = new AbstractInt(12);
     trace(a); // 12


### PR DESCRIPTION
Currently the class declared within `MyAbstract.hx` is named `Main` instead of `MyAbstract` which is a problem given the module name does not match the class's name.