### PR TITLE
Add sys and io examples

### DIFF
--- a/assets/Process.hx
+++ b/assets/Process.hx
@@ -1,0 +1,12 @@
+class Main {
+  static function main() {
+    final gitCommand = 'git log --format=short --no-decorate -n1 --oneline';
+    final process = new sys.io.Process(gitCommand);
+    if (process.exitCode() != 0) {
+      trace("Error running process command");
+    }
+    final lastCommitInfo = process.stdout.readLine();
+    trace(lastCommitInfo);
+    process.close();
+  }
+}

--- a/content/10-std.md
+++ b/content/10-std.md
@@ -970,7 +970,10 @@ Older browsers (Internet Explorer 7, for instance) may not have a native **JSON*
 <!--label:std-input-output-->
 ### Input/Output
 
-<!--subtoc-->
+Haxe has two packages that group Input/Output utilities:
+
+- [haxe.io](https://api.haxe.org/haxe/io/) which is available for all targets.
+- [sys.io](https://api.haxe.org/sys/io/) which is available for [sys targets](https://haxe.org/documentation/introduction/compiler-targets.html).
 
 
 
@@ -996,8 +999,28 @@ All spawned threads are treated as daemon threads, meaning that the main thread 
 
 Due to threads having access to a shared memory space with all the Haxe variables and objects, it is possible to run into issues due to deadlocks and race conditions. The standard library provides some core synchronization constructs in the [`sys.thread`](https://api.haxe.org/sys/thread/) package.
 
+<!--label:std-sys-standard-io-streams-->
+#### Standard IO Streams
 
+Using the `Sys` module you have access to the three standard streams `stdin`, `stdout` and `stderr`.
 
+```haxe
+// Printing without using trace, useful to print without a newline character
+Sys.stdout().writeString('Please type your name: ');
+// Flush characters to terminal
+Sys.stdout().flush();
+
+// Reading user input through terminal
+final input = Sys.stdin().readLine();
+trace('Hello ${input}}!');
+```
+
+<!--label:std-input-output-process-->
+#### Process
+
+Haxe supports the spawning and management of new processes using the [Process](https://api.haxe.org/sys/io/Process.html) class, here's an example of running a git command and reading its output:
+
+[code asset](assets/Process.hx)
 
 
 <!--label:std-remoting-->

--- a/tests/RunTravis.hx
+++ b/tests/RunTravis.hx
@@ -91,6 +91,7 @@ class RunTravis
 		"HelloPHP.hx", // PHP only
 		"JSRequireModule.hx",
 		"JSRequireObject.hx",
+		"Process.hx", // requires git
 		"RestAndEitherType.hx", // requires an extern
 		"SwitchStatement.hx", // pseudo-code
 		"UnitTestCase.hx",


### PR DESCRIPTION
- Added Streams and Process pages to the Sys section.
- Added a small text to the empty input/output page (#16).

I also excluded the Process example from running since I'm not sure if it would fail on Travis CI.