### PR TITLE
Add example of Array comprehesion expression

### DIFF
--- a/assets/ArrayComprehension.hx
+++ b/assets/ArrayComprehension.hx
@@ -6,5 +6,8 @@ class Main {
     var i = 0;
     var b = [while (i < 10) i++];
     trace(b); // [0,1,2,3,4,5,6,7,8,9]
+
+    var squares = [for (i in 0...10) i*i];
+    trace(squares); // [0,1,4,9,16,25,36,49,64,81]
   }
 }


### PR DESCRIPTION
This adds an example of how to use expressions in a for loop array comprehension.

This is something found in other programming languages (and yet others use `map` for this) so for programmers who know this it will be valuable to see a minimal example of how it's done in haxe.