### PR TITLE
Fix the email regex example

### DIFF
--- a/content/10-std.md
+++ b/content/10-std.md
@@ -284,7 +284,7 @@ We can use standard regular expression patterns such as:
 
 For example, the following regular expression matches valid email addresses:
 ```haxe
-~/[A-Z0-9._%-]+@[A-Z0-9.-]+.[A-Z][A-Z][A-Z]?/i;
+~/[A-Z0-9._%-]+@[A-Z0-9.-]+\.[A-Z][A-Z][A-Z]*/i;
 ```
 
 Please notice that the `i` at the end of the regular expression is a **flag** that enables case-insensitive matching.


### PR DESCRIPTION
The dot was not escaped, which would allow an email like "bob@example/com" to be matched.

The example assumed that domain names are 2 or 3 characters long.
This is not true anymore (see https://en.wikipedia.org/wiki/List_of_Internet_top-level_domains).

There are still a lot of ways to be pedantic about email adresses because technically a lot more addresses are valid, but this matches most addresses in practice.