### PR TITLE
Improve definition of `private` in Haxe

### DIFF
--- a/content/04-class-field.md
+++ b/content/04-class-field.md
@@ -272,7 +272,7 @@ Omitting the visibility modifier usually defaults the visibility to `private`, b
 
 > ##### Trivia: Protected
 >
-> Haxe does not support the `protected` behavior known from many other object-oriented programming languages like Java and C++. However, Haxe's `private` behaves similarly to `protected` in other languages, but does not allow access from non-inheriting classes in the same package.
+> Haxe does not support the `protected` keyword known from many other object-oriented programming languages like Java and C++. However, Haxe's `private` behaves similarly to `protected` in other languages, but does not allow access from non-inheriting classes in the same package.
 
 
 

--- a/content/04-class-field.md
+++ b/content/04-class-field.md
@@ -272,7 +272,7 @@ Omitting the visibility modifier usually defaults the visibility to `private`, b
 
 > ##### Trivia: Protected
 >
-> Haxe has no notion of a `protected` keyword known from Java, C++ and other object-oriented languages. However, its `private` behavior is equal to those language's protected behavior, so Haxe actually lacks their real private behavior.
+> Haxe does not support the `protected` behavior known from many other object-oriented programming languages like Java and C++. However, Haxe's `private` behaves similarly to `protected` in other languages, but does not allow access from non-inheriting classes in the same package.
 
 
 


### PR DESCRIPTION
The documenation says that Haxe does not support the keyword `protected` known from many other object-oriented languages, but its `private` behaves analogously. This is only partially true, however, because Java, for example, allows access to methods/fields even from non-inheriting classes in the same package when declared as `protected`. Haxe does not.

![Oracle Docs](https://cdn.discordapp.com/attachments/162395145352904705/881191350912045136/unknown.png)
[See docs](https://docs.oracle.com/javase/tutorial/java/javaOO/accesscontrol.html)

I have updated the description of Haxe's `private` behavior to better convey what it does.