### PR TITLE
Made corrections for new php target argument syntax

### DIFF
--- a/content/07-compiler-usage.md
+++ b/content/07-compiler-usage.md
@@ -61,9 +61,9 @@ The second question usually comes down to providing an argument specifying the d
 
 ##### Target specific arguments
 
-* `--php-front <filename>` Select the name for the php front file.
-* `--php-lib <filename>` Select the name for the php lib folder.
-* `--php-prefix <name>` Prefix all classes with given name.
+* `-D php-front=<filename>` Select the name for the php front file.
+* `-D php-lib=<filename>` Select the name for the php lib folder.
+* `-D php-prefix=<name>` Prefix all classes with given name.
 * `--swf-version <version>` Change the SWF version.
 * `--swf-header <header>` Define SWF header (width:height:fps:color).
 * `--swf-lib <file>` Add the SWF library to the compiled SWF.


### PR DESCRIPTION
I discovered the old syntax was deprecated, per [this change](https://github.com/HaxeFoundation/haxe/blob/279f459/extra/CHANGES.txt#L509).