### PR TITLE
Updated string literal documentation

### DIFF
--- a/content/10-std.md
+++ b/content/10-std.md
@@ -40,10 +40,24 @@ String literals may occupy multiple lines; In which case, each line of the strin
 
 ```haxe
 var str = "Line one
-	Line two
-	Line three"; //Lines two and three have \t in them
+Line two
+Line three";
 trace(str);
 ```
+
+Note that indentation will also be included in the string, such as with the example below.
+
+```haxe
+class X {
+  function foo() {
+    var str = "a
+    b
+    c";
+  }
+}
+```
+
+The `str` variable will have a '\t' tab character before 'b' and 'c'.
 
 ##### Escape sequences
 

--- a/content/10-std.md
+++ b/content/10-std.md
@@ -36,6 +36,15 @@ trace(a == b); // true
 
 The only difference between the two forms is that single-quoted literals allow [string interpolation](lf-string-interpolation).
 
+String literals may occupy multiple lines; In which case, each line of the string will be punctuated with a '\n' newline character (See the escape sequences chart below).
+
+```haxe
+var str = "Line one
+	Line two
+	Line three"; //Lines two and three have \t in them
+trace(str);
+```
+
 ##### Escape sequences
 
 Sequence | Meaning | Unicode codepoint (decimal) | Unicode codepoint (hexadecimal)

--- a/content/10-std.md
+++ b/content/10-std.md
@@ -57,7 +57,7 @@ class X {
 }
 ```
 
-The `str` variable will have a '\t' tab character before 'b' and 'c'.
+The `str` variable will have four spaces before 'b' and 'c'.
 
 ##### Escape sequences
 


### PR DESCRIPTION
Included paragraph explaining that string literals can occupy multiple lines, rather than there being a special language construct for doing so.