### PR TITLE
Document constructor inlining limitations.

### DIFF
--- a/content/06-lf.md
+++ b/content/06-lf.md
@@ -939,11 +939,11 @@ This is also true for access granted to parent classes, in which case it extends
 
 ##### since Haxe 3.1.0
 
-If a constructor is declared to be [inline](class-field-inline), the compiler may try to optimize it away in certain situations. There are several requirements for this to work:
+If a constructor is declared to be [inline](class-field-inline), the compiler may try to optimize it away in certain situations. For this to work, the compiler must be able to verify that the object can be replaced by a set of local variables.
 
-* The constructor must only contain assignments to its instance fields.
-* The newly-constructed instance must only be accessible from the enclosing function.
-* If the new instance is assigned to a variable, that variable must be deconstructible, meaning among other things, it may not be reassigned.
+* The newly-constructed instance must only be accessible from the local function.
+* All called instance functions must be inlined.
+* All other references to the instance must only read or write its variables.
 
 The following example demonstrates constructor inlining:
 

--- a/content/06-lf.md
+++ b/content/06-lf.md
@@ -942,6 +942,7 @@ This is also true for access granted to parent classes, in which case it extends
 If a constructor is declared to be [inline](class-field-inline), the compiler may try to optimize it away in certain situations. There are several requirements for this to work:
 
 * The result of the constructor call must be directly assigned to a local variable.
+* The local variable must not be reassigned, passed to another function, or returned from the local function.
 * The expression of the constructor field must only contain assignments to its fields.
 
 The following example demonstrates constructor inlining:

--- a/content/06-lf.md
+++ b/content/06-lf.md
@@ -941,9 +941,9 @@ This is also true for access granted to parent classes, in which case it extends
 
 If a constructor is declared to be [inline](class-field-inline), the compiler may try to optimize it away in certain situations. There are several requirements for this to work:
 
-* The result of the constructor call must be directly assigned to a local variable.
-* The local variable must not be reassigned, passed to another function, or returned from the local function.
-* The expression of the constructor field must only contain assignments to its fields.
+* The constructor must only contain assignments to its instance fields.
+* The newly-constructed instance must only be accessible from the enclosing function.
+* If the new instance is assigned to a variable, that variable must be deconstructible, meaning among other things, it may not be reassigned.
 
 The following example demonstrates constructor inlining:
 


### PR DESCRIPTION
[Here's some code demonstrating the limitations](https://try.haxe.org/#b4E6abfa).

```haxe
class InlineConstructorTest {
  static function main() {
    //Can't be inlined because `object1` is reassigned later.
    var object1:SimpleObject = new SimpleObject("one");
    object1 = new SimpleObject("uno");
    
    //Can be inlined.
    var object2:SimpleObject = new SimpleObject("two");
    object2.name = "dos";
    
    //Can't be inlined because `object3` is passed to a function.
    var object3:SimpleObject = new SimpleObject("three");
    if(Reflect.fields(object3).length > 0) {
      object3.name = "tres";
    }
    
    trace(object1.name);
    trace(object2.name);
    trace(object3.name);
    printObject4();
  }
  
  static inline function printObject4():SimpleObject {
    //Can't be inlined because `object4` is returned.
    var object4:SimpleObject = new SimpleObject("cuatro");
    trace(object4.name);
    return object4;
  }
}

class SimpleObject {
  public var name:String;
  
  public inline function new(name:String) {
    this.name = name;
  }
}
```