### PR TITLE
Add `@:keep` to sample function

### DIFF
--- a/assets/TemplateMacros.hx
+++ b/assets/TemplateMacros.hx
@@ -11,7 +11,7 @@ class Main {
     trace(output);
   }
 
-  function display(resolve:String->Dynamic, user:User, time:Int) {
+  @:keep function display(resolve:String->Dynamic, user:User, time:Int) {
     return user.name + " ran " + (user.distance / 1000) + " kilometers in " +
       time + " minutes";
   }

--- a/content/10-std.md
+++ b/content/10-std.md
@@ -615,7 +615,8 @@ The console will trace `The users are Mark(30) John(45)`.
 ##### Template macros
 To call custom functions while parts of the template are being rendered, provide a `macros` object to the argument of [Template.execute](https://api.haxe.org/haxe/Template.html#execute). The key will act as the template variable name, the value refers to a callback function that should return a `String`. The first argument of this macro function is always a `resolve()` method, followed by the given arguments. The resolve function can be called to retrieve values from the template context. If `macros` has no such field, the result is unspecified.
 
-The following example passes itself as macro function context and executes `display` from the template.
+The following example passes itself as macro function context and executes `display` from the template. Because `display` isn't called anywhere else, `@:keep` is used to prevent DCE from removing it.
+
 [code asset](assets/TemplateMacros.hx)
 
 The console will trace `The results: Mark ran 3.5 kilometers in 15 minutes`.


### PR DESCRIPTION
Otherwise, DCE would clean it up and break the sample. Granted, you wouldn't typically run a sample with DCE, but if users were to copy the code into their own project, they could run into the issue there.

Resolves #475.