### PR TITLE
Update for 4.3

### DIFF
--- a/assets/AbstractCallOverload.hx
+++ b/assets/AbstractCallOverload.hx
@@ -1,0 +1,15 @@
+abstract MyAbstract(Int) from Int {
+  @:op(a()) public function callNoArgs():Int
+    return this;
+
+  @:op(a()) public function callOneArg(x:Int):Int
+    return x + this;
+}
+
+class Main {
+  static public function main() {
+    var s:MyAbstract = 42;
+    trace(s()); // uses callNoArgs, outputs 42
+    trace(s(1)); // uses callOneArg, ouputs 43
+  }
+}

--- a/assets/LocalStatic.hx
+++ b/assets/LocalStatic.hx
@@ -1,0 +1,19 @@
+class Main {
+  static function getData() {
+    static var cache:Null<String> = null;
+    if (cache == null) {
+      cache = slowOperation();
+    }
+    return cache;
+  }
+
+  static function slowOperation() {
+    trace("performing slow operation...");
+    return "result";
+  }
+
+  static public function main() {
+    trace(getData()); // performing slow operation... result
+    trace(getData()); // result
+  }
+}

--- a/assets/MyAbstract2.hx
+++ b/assets/MyAbstract2.hx
@@ -1,0 +1,19 @@
+abstract AbstractInt(Int) {
+  inline public function new(i:Int) {
+    this = i;
+  }
+  inline public function test() {
+    Main.takeAbstractInt(abstract);
+  }
+}
+
+class Main {
+  static public function takeAbstractInt(x:AbstractInt) {
+    // ...
+  }
+
+  static public function main() {
+    var a = new AbstractInt(12);
+    a.test();
+  }
+}

--- a/assets/TypeParameterDefault.hx
+++ b/assets/TypeParameterDefault.hx
@@ -1,0 +1,19 @@
+class Example<T = Int, U = Int> {
+  public var a:T;
+  public var b:U;
+  public function new() {}
+}
+
+function main():Void {
+  var x:Example = new Example();
+  $type(x.a); // Int
+  $type(x.b); // Int
+
+  var y:Example<Bool> = new Example();
+  $type(y.a); // Bool
+  $type(y.b); // Int
+
+  var z:Example<String, Int> = new Example();
+  $type(z.a); // String
+  $type(z.b); // Int
+}

--- a/content/02-types.md
+++ b/content/02-types.md
@@ -20,7 +20,7 @@ We will explore type inference in detail later in [Type Inference](type-system-t
 
 The Haxe type system knows seven type groups:
 
- * **Class instance**: an object of a given class or interface 
+* **Class instance**: an object of a given class or interface 
 * **Enum instance**: a value of a Haxe enumeration 
 * **Structure**: an anonymous structure, i.e. a collection of named fields 
 * **Function**: a compound type of several arguments and one return 
@@ -870,6 +870,27 @@ One problem may be apparent - what happens if a member function is not declared 
 >
 > Before the advent of abstract types, all basic types were implemented as extern classes or enums. While this nicely took care of some aspects such as `Int` being a "child class" of `Float`, it caused issues elsewhere. For instance, with `Float` being an extern class, it would unify with the empty structure `{}`, making it impossible to constrain a type to accept only real objects.
 
+<!--label:types-abstract-this-->
+#### Access to Underlying Data
+
+As shown in the example from the previous section, `this` in abstract methods refers to the underlying data. For `AbstractInt` methods, `this` is therefore a variable of type `Int`.
+
+[code asset](assets/MyAbstract.hx#L1-L5)
+
+##### since Haxe 4.3.0
+
+The `abstract` keyword can be used in abstract methods to refer to the current instance *as an abstract type*, rather than referring to the underlying data with the `this` keyword.
+
+This can be useful when an abstract method needs to call other methods which accept an argument of the abstract type. For example, suppose class `Main` defines a method `takeAbstractInt`:
+
+[code asset](assets/MyAbstract2.hx#L11-L13)
+
+To call `takeAbstractInt` from within an `AbstractInt` method, we must use the `abstract` keyword:
+
+[code asset](assets/MyAbstract2.hx#L5-L7)
+
+If we instead wrote `Main.takeAbstractInt(this)`, this would be a type error, because `takeAbstractInt` does not accept an argument of type `Int`.
+
 <!--label:types-abstract-implicit-casts-->
 #### Implicit Casts
 
@@ -969,7 +990,11 @@ The method body of an `@:op` function can be omitted, but only if the underlying
 
 [code asset](assets/AbstractExposeTypeOperations.hx)
 
+##### since Haxe 4.3.0
 
+The `@:op(a())` syntax can be used to overload function calls on abstracts. The metadata is attached to a function, and the signature of that function determines the signature of the call to the abstract. Multiple functions with different signatures can be annotated this way to support overloading:
+
+[code asset](assets/AbstractCallOverload.hx)
 
 <!--label:types-abstract-array-access-->
 #### Array Access

--- a/content/03-type-system.md
+++ b/content/03-type-system.md
@@ -95,6 +95,14 @@ When constraining to a single type, the parentheses can be omitted:
 
 One of the breaking changes between versions 3 and 4 is the multiple type constraint syntax. As the first example above shows, in Haxe 4 the constraints are separated by an `&` symbol instead of a comma. This is similar to the new [structure extension](types-structure-extensions) syntax.
 
+<!--label:type-system-type-parameter-defaults-->
+#### Defaults
+
+Since Haxe 4.3 it is possible to specify a default type for each type parameter of a type. When using such a type in type annotations, type parameters with a default can be omitted:
+
+[code asset](assets/TypeParameterDefault.hx)
+
+
 
 
 

--- a/content/04-class-field.md
+++ b/content/04-class-field.md
@@ -370,6 +370,10 @@ All fields are member fields unless the modifier `static` is used. Static fields
 
 Static [variable](class-field-variable) and [property](class-field-property) fields can have arbitrary initialization [expressions](expression).
 
+##### since Haxe 4.3.0
+
+Static fields should not be confused with [local static variables](expression-local-static).
+
 
 
 <!--label:class-field-extern-->

--- a/content/05-expression.md
+++ b/content/05-expression.md
@@ -492,6 +492,45 @@ This syntax is also used to access types within packages in the form of `pack.Ty
 
 The typer ensures that an accessed field actually exist and may apply transformations depending on the nature of the field. If a field access is ambiguous, understanding the [resolution order](type-system-resolution-order) may help.
 
+##### since Haxe 4.3.0
+
+Null-safe field access is expressed using the `?.` operator. Such access checks if the object is not `null` first, and only then accesses the given field. If the object *is* `null`, then the entire expression has the value `null`.
+
+```haxe
+object?.fieldName
+```
+
+This is roughly the same as:
+
+```haxe
+(object != null ? object.fieldName : null)
+```
+
+However, `object` is not evaluated twice.
+
+The null-safe field access can be chained, allowing a much cleaner access to deeply nested data where each step may be `null`, which may be the case when dealing with externs in a dynamically typed language, for example.
+
+
+
+<!--label:expression-null-coalesce-->
+### Null coalescing
+
+##### since Haxe 4.3.0
+
+Complementing [null-safe field access](expression-field-access), the null coalescing operator `??` allows specifying a default/fallback value if a given expression is `null`.
+
+```haxe
+value ?? "fallback"
+```
+
+This roughly the same as:
+
+```haxe
+value != null ? value : "fallback"
+```
+
+However, `value` is not evaluated twice.
+
 
 
 <!--label:expression-array-access-->
@@ -556,6 +595,21 @@ In Haxe 4, the alternative keyword `final` was introduced at the expression leve
 It is important to note that `final` may not have the intended effect with types that are not immutable, such as arrays or objects. Even though the variable cannot have a different object assigned to it, the object itself can still be modified using its methods:
 
 [code asset](assets/FinalMutable.hx)
+
+
+
+<!--label:expression-local-static-->
+### Local static variables
+
+##### since Haxe 4.3.0
+
+`static var` and `static final` declarations within a function create variables that are scoped to the function (they cannot be referred to from outside the function), but are only initialized once.
+
+This can be used to implement a cache or memoization pattern for functions without creating too many class fields.
+
+[code asset](assets/LocalStatic.hx)
+
+Similarly to [static class variables](class-field-static), the initial value assigned to a local static variable (if any) must not refer to instance variables or arguments of the current function.
 
 
 

--- a/content/06-lf.md
+++ b/content/06-lf.md
@@ -278,6 +278,22 @@ In `Main.hx` we can use `somepackage.Example` module. This module is defined in 
 
 
 
+<!--label:lf-custom-defines-documentation-->
+#### Custom defines documentation
+
+##### since Haxe 4.3.0
+
+As noted in [conditional compilation](lf-condition-compilation), custom defines can always be added on the command line with `-D ...`. However, to provide better completion in the IDE, and to provide documentation for a Haxe user, defines can be registered with the compiler in [initialization macros](macro-initialization) using the methods:
+
+* [`registerDefinesDescriptionFile`](https://api.haxe.org/v/development/haxe/macro/Compiler.html#registerDefinesDescriptionFile)
+* [`registerCustomDefine`](https://api.haxe.org/v/development/haxe/macro/Compiler.html#registerCustomDefine)
+
+The compiler argument `--help-user-defines` displays a list of registered defines.
+
+```sh
+haxe --lib somelibrary --lib another --help-user-defines
+```
+
 
 
 <!--label:lf-externs-->
@@ -875,6 +891,24 @@ Prior to Haxe 4, metadata names had to be valid identifiers. Starting in Haxe 4,
 ##### Related content
 
 * See also the [Compiler Metadata list](cr-metadata).
+
+
+
+<!--label:lf-custom-metadata-documentation-->
+#### Custom metadata documentation
+
+##### since Haxe 4.3.0
+
+Similarly to [custom defines documentation](lf-custom-defines-documentation), initialization macros can provide IDE completion and documentation for custom metadata using the methods:
+
+* [`registerMetadataDescriptionFile`](https://api.haxe.org/v/development/haxe/macro/Compiler.html#registerMetadataDescriptionFile)
+* [`registerCustomMetadata`](https://api.haxe.org/v/development/haxe/macro/Compiler.html#registerCustomMetadata)
+
+The compiler argument `--help-user-metas` displays a list of registered metadata.
+
+```sh
+haxe --lib somelibrary --lib another --help-user-metas
+```
 
 
 

--- a/content/07-compiler-usage.md
+++ b/content/07-compiler-usage.md
@@ -178,3 +178,41 @@ Flag | Argument | Description | Platforms
 <!--include:generated/defines.md-->
 
 
+
+<!--label:compiler-usage-reporting-->
+### Error Reporting
+
+##### since Haxe 4.3.1
+
+The compiler can be configured to report errors and warnings in a format more readable on the command line. The define for this is `-D message.reporting=(mode)`, and the available modes are:
+
+* `classic` - the default, plain text format.
+* `indent` - similar to `classic`, but sub-messages (related errors or explanations of errors) are indented.
+* `pretty` - adds more contextual information to errors. For example, the expression or code fragment related to the error is displayed and highlighted with the error message.
+
+By default, the `pretty` mode uses ANSI escape codes to color the output to make it more navigable. The coloring can be turned off with `-D message.no-color`.
+
+Examples of each mode for the same error:
+
+```
+$ haxe --run Example
+Example.hx:3: characters 9-13 : Bool should be Int
+Example.hx:3: characters 9-13 : ... For function argument 'x'
+```
+
+```
+$ haxe -D message.reporting=indent --run Example
+Example.hx:3: characters 9-13 : Bool should be Int
+  Example.hx:3: characters 9-13 : For function argument 'x'
+```
+
+```
+$ haxe -D message.reporting=pretty --run Example
+ ERROR  Example.hx:3: characters 9-13
+
+ 3 |     foo(true);
+   |         ^^^^
+   | Bool should be Int
+   | For function argument 'x'
+
+```

--- a/content/09-macro.md
+++ b/content/09-macro.md
@@ -124,6 +124,10 @@ This kind of reification only works in places where the internal structure expec
 
 Furthermore, a `new` expression can be reified by providing [haxe.macro.TypePath](http://api.haxe.org/haxe/macro/TypePath.html) argument: `new $typePath()`
 
+##### since Haxe 4.3.0
+
+Using the `$` escape modifiers described above is no longer allowed outside of a `macro` expression. This does not limit any applications though: in cases where this was previously allowed, the `$` escape modifier was not necessary. For example: `var x = $v{MacroTools.example()}` should simply become `var x = MacroTools.example()`.
+
 
 
 <!--label:macro-reification-type-->


### PR DESCRIPTION
Closes #524 (except for the `-w` comment).

- new section in Types: [Access to Underlying Data](https://github.com/HaxeFoundation/HaxeManual/blob/feature/4.3/content/02-types.md#access-to-underlying-data) (about the `abstract` keyword)
- expanded section on [operator overloading](https://github.com/HaxeFoundation/HaxeManual/blob/feature/4.3/content/02-types.md#since-haxe-430-1) to explain `@:op(a())`
- new section in Type System: [Default type parameters](https://github.com/HaxeFoundation/HaxeManual/blob/feature/4.3/content/03-type-system.md#defaults)
- new section in Expressions: [Local static variables](https://github.com/HaxeFoundation/HaxeManual/blob/feature/4.3/content/05-expression.md#local-static-variables)
  - (also added a note to static class fields linking to this)
- expanded section on [field access](https://github.com/HaxeFoundation/HaxeManual/blob/feature/4.3/content/05-expression.md#since-haxe-430) with null-safe field access
- new section in Expressions: [Null coalescing](https://github.com/HaxeFoundation/HaxeManual/blob/feature/4.3/content/05-expression.md#null-coalescing)
- new section in Language Features: [Custom defines documentation](https://github.com/HaxeFoundation/HaxeManual/blob/feature/4.3/content/06-lf.md#custom-defines-documentation)
- new section in Language Features: [Custom metadata documentation](https://github.com/HaxeFoundation/HaxeManual/blob/feature/4.3/content/06-lf.md#custom-metadata-documentation)
- new section in Compiler Usage: [Error Reporting](https://github.com/HaxeFoundation/HaxeManual/blob/feature/4.3/content/07-compiler-usage.md#error-reporting)
- expanded section on [expression reification](https://github.com/HaxeFoundation/HaxeManual/blob/feature/4.3/content/09-macro.md#since-haxe-430) to explain that `$` escapes are not allowed outside of `macro` expressions

Left to do:

- [ ] `-w` documentation (@simn wanted to take this?)