### PR TITLE
Fix comparison between bitwise and comparison operator precedences

### DIFF
--- a/content/05-expression.md
+++ b/content/05-expression.md
@@ -464,7 +464,7 @@ Many languages (C++, Java, PHP, JavaScript, etc) use the same operator precedenc
 
 * `%` (modulo) has a higher precedence than `*` and `/`; in C they have the same precedence
 * <code>&#124;</code>, `&`, `^` (bitwise operators) have the same precedence; in C the three operators all have a different precedence
-* <code>&#124;</code>, `&`, `^` (bitwise operators) also have a lower precedence than `==`, `!=`, etc (comparison operators)
+* <code>&#124;</code>, `&`, `^` (bitwise operators) also have a higher precedence than `==`, `!=`, etc (comparison operators)
 
 
 


### PR DESCRIPTION
As the [preceding table](https://haxe.org/manual/expression-operators-precedence.html) shows, bitwise operators in Haxe have *higher* precedence than comparison operators.