### PR TITLE
Update hxcpp setup instructions for windows

### DIFF
--- a/content/12-target-details.md
+++ b/content/12-target-details.md
@@ -693,7 +693,7 @@ On Mac, it is recommended that you install the latest Xcode from the Mac App Sto
 
 On Linux, it is recommended that you use the system package manager to install the compilers.
 
-On Windows, Microsoft Visual Studio is recommended. On Windows, you can also use `gcc`-based compilers. A minimal distribution is included in a Haxelib library, and can be installed with `haxelib install minimingw`.
+On Windows, Microsoft Visual Studio is recommended. You can also use `gcc`-based compilers.
 
 ##### Cross Compilers
 

--- a/content/12-target-details.md
+++ b/content/12-target-details.md
@@ -695,6 +695,13 @@ On Linux, it is recommended that you use the system package manager to install t
 
 On Windows, Microsoft Visual Studio is recommended. You can also use `gcc`-based compilers.
 
+To compile with Microsoft Visual Studio, you need to install the Builds Tools and `vswhere`. You can install the 2022 Build Tools and `vswhere` using the following winget commands:
+
+```pwsh
+winget install -e --id Microsoft.VisualStudio.2022.BuildTools
+winget install -e --id Microsoft.VisualStudio.Locator
+```
+
 ##### Cross Compilers
 
 `hxcpp` can be used to compile for non-host architectures if you have a suitable cross-compiler installed. The compilers are usually supplied in the form of a Software Development Kits (SDK), or in the case of iOS devices, come with the system compiler (Xcode). Selecting which compiler to use is achieved by defining particular variables in the `hxcpp` build environment. Note that the `hxcpp` build tool is only responsible for producing a native executable or a native library (static or dynamic), not the complete bundling and packaging of assets and meta-data that is typically required for mobile devices. Additional Haxe libraries can be used for this task.


### PR DESCRIPTION
minimingw is very outdated and it no longer works: https://github.com/nmehost/minimingw/issues/1. We should stop recommending it as it's causing users to run into errors: https://github.com/HaxeFoundation/haxe.org-comments/issues/136#issuecomment-2049392211 https://github.com/HaxeFoundation/haxe.org-comments/issues/30#issuecomment-1374414669 https://github.com/HaxeFoundation/hxcpp/issues/789

Closes https://github.com/HaxeFoundation/hxcpp/issues/789

I've also added information about how to set up MSVC. Closes https://github.com/HaxeFoundation/HaxeManual/issues/521.