### PR TITLE
Avoid Dynamic example in DynamicAccess

### DIFF
--- a/assets/DynamicAccess.hx
+++ b/assets/DynamicAccess.hx
@@ -1,16 +1,27 @@
-class Main {
-  static public function main() {
-    var user:haxe.DynamicAccess<Dynamic> = {};
+class Test {
+	static function main() {
+		var users:haxe.DynamicAccess<User> = {
+			John: { surname: "Smith", age: 24 },
+			Patti: { surname: "Mayonaise", age: 16 }
+		};
 
-    // Sets values for specified keys.
-    user.set("name", "Mark");
-    user.set("age", 25);
+		// Get user John, throw him a brithday
+		var john = users.get("John");
+		john.age++;
 
-    // Returns values by specified keys.
-    trace(user.get("name")); // "Mark"
-    trace(user.get("age")); // 25
+		trace('$name ${john.surname} is ${john.age} years old'); // John Smith is 25 years old
 
-    // Tells if the structure contains a specified key
-    trace(user.exists("name")); // true
-  }
+		// Add new user
+		users.set("Mark", { surname: "McCartney", age:30 });
+
+	    // Whether the structure contains a specified key
+	    trace(user.exists("Mark")); // true
+
+		// Output all users
+		for (name => data in users) {
+			trace('$name ${data.surname} is ${data.age} years old');
+		}
+	}
 }
+
+typedef User = { surname:String, age:Int };


### PR DESCRIPTION
I think using a type param other than Dynamic makes it more clear what the type param is actually used for