### PR TITLE
add `--json <file>` in compiler defines / usage section

### DIFF
--- a/content/07-compiler-usage.md
+++ b/content/07-compiler-usage.md
@@ -42,6 +42,7 @@ The second question usually comes down to providing an argument specifying the d
 ##### Other global arguments
 * `--run <module> [args...]` Compile and execute a Haxe module with command line arguments.
 * `--xml <file>` Generate XML types description. Useful for API documentation generation tools like [Dox](https://github.com/HaxeFoundation/dox).
+* `--json <file>` Generate JSON types description. 
 * `-v` (or `--verbose`) Turn on verbose mode.
 * <code>--dce &lt;std&#124;full&#124;no&gt;</code> Set the [Dead Code Elimination](cr-dce) mode (default `std`).
 * `--debug` Add debug information to the compiled code.


### PR DESCRIPTION
was brought up by @joshtynjala in https://github.com/openfl/lime/pull/1882#issuecomment-2573632687

I'm unsure when the `--json` flag was implemented in Haxe, but as of 4.3.6 it shows up in `haxe --help-defines` so I think it should be included here as well :)