### PR TITLE
Add Macro > Arguments > Instance argument

### DIFF
--- a/assets/InstanceExprArgMacro.hx
+++ b/assets/InstanceExprArgMacro.hx
@@ -13,18 +13,18 @@ class Logger {
 		haxe.Log.trace('$id: $logID = [$data]', pos);
 	}
 	
-	macro public function logExpr(inst:Expr, data:Expr):Expr {
-		return eval(inst, data);
+	macro public function logExpr(instance:Expr, data:Expr):Expr {
+		return eval(instance, data);
 	}
 	
 	#if macro
-	static public function eval(inst:Expr, obj:Expr):Expr {
+	static public function eval(instance:Expr, obj:Expr):Expr {
 		final str = MacroStringTools.formatString;
 		final id = str('${ExprTools.toString(obj)}', obj.pos);
 		
 		return macro {
 			@:pos(obj.pos)
-			$inst.log($obj, $id);
+			$instance.log($obj, $id);
 		};
 	}
 	#end

--- a/assets/InstanceExprArgMacro.hx
+++ b/assets/InstanceExprArgMacro.hx
@@ -19,8 +19,7 @@ class Logger {
 	
 	#if macro
 	static public function eval(instance:Expr, obj:Expr):Expr {
-		final str = MacroStringTools.formatString;
-		final id = str('${ExprTools.toString(obj)}', obj.pos);
+		final id = MacroStringTools.formatString('${ExprTools.toString(obj)}', obj.pos);
 		
 		return macro {
 			@:pos(obj.pos)

--- a/assets/InstanceExprArgMacro.hx
+++ b/assets/InstanceExprArgMacro.hx
@@ -1,0 +1,31 @@
+import haxe.macro.Expr;
+import haxe.macro.ExprTools;
+import haxe.macro.MacroStringTools;
+
+// use this for macros or other classes
+class Logger {
+	public final id:String;
+	public function new(id:String) {
+		this.id = id;
+	}
+	
+	inline public function log(data:Any, logID:String, ?pos) {
+		haxe.Log.trace('$id: $logID = [$data]', pos);
+	}
+	
+	macro public function logExpr(inst:Expr, data:Expr):Expr {
+		return eval(inst, data);
+	}
+	
+	#if macro
+	static public function eval(inst:Expr, obj:Expr):Expr {
+		final str = MacroStringTools.formatString;
+		final id = str('${ExprTools.toString(obj)}', obj.pos);
+		
+		return macro {
+			@:pos(obj.pos)
+			$inst.log($obj, $id);
+		};
+	}
+	#end
+}

--- a/assets/InstanceExprArgUsage.hx
+++ b/assets/InstanceExprArgUsage.hx
@@ -1,0 +1,12 @@
+class Test {
+	static function main() {
+		final factLogger = new Logger("Fact");
+		final lieLogger = new Logger("Lie");
+		
+		final theory1 = {statement: "Haxe is great!", conclusion: true};
+		final theory2 = {statement: "7 > 9", conclusion: false};
+		
+		(theory1.conclusion ? factLogger : lieLogger).logExpr(theory1.statement);
+		(theory2.conclusion ? factLogger : lieLogger).logExpr(theory2.statement);
+	}
+}

--- a/content/09-macro.md
+++ b/content/09-macro.md
@@ -89,6 +89,7 @@ If the final argument of a macro is of type `Array<Expr>`, the macro accepts an 
 [code asset](assets/MacroArgumentsRest.hx)
 
 
+
 <!--label:macro-instance-arg-->
 #### Instance argument
 
@@ -105,6 +106,8 @@ This outputs at runtime:
 Test.hx:9: Fact: theory1.statement = [Haxe is great!]
 Test.hx:10: Lie: theory2.statement = [7 > 9]
 ```
+
+
 
 <!--label:macro-reification-->
 ### Reification

--- a/content/09-macro.md
+++ b/content/09-macro.md
@@ -94,54 +94,12 @@ If the final argument of a macro is of type `Array<Expr>`, the macro accepts an 
 
 If the macro is an instance method, the first arg will be the expression used to reference the instance:
 
-```haxe
-import haxe.macro.Expr;
-import haxe.macro.ExprTools;
-import haxe.macro.MacroStringTools;
+[code asset](assets/InstanceExprArgMacro.hx)
 
-// use this for macros or other classes
-class Logger {
-	public final id:String;
-	public function new(id:String) {
-		this.id = id;
-	}
-	
-	inline public function log(data:Any, logID:String, ?pos) {
-		haxe.Log.trace('$id: $logID = [$data]', pos);
-	}
-	
-	macro public function logExpr(inst:Expr, data:Expr):Expr {
-		return eval(inst, data);
-	}
-	
-	#if macro
-	static public function eval(inst:Expr, obj:Expr):Expr {
-		final str = MacroStringTools.formatString;
-		final id = str('${ExprTools.toString(obj)}', obj.pos);
-		
-		return macro {
-			@:pos(obj.pos)
-			$inst.log($obj, $id);
-		};
-	}
-	#end
-}
-```
 Usage:
-```haxe
-class Test {
-	static function main() {
-		final factLogger = new Logger("Fact");
-		final lieLogger = new Logger("Lie");
-		
-		final theory1 = {statement: "Haxe is great!", conclusion: true};
-		final theory2 = {statement: "7 > 9", conclusion: false};
-		
-		(theory1.conclusion ? factLogger : lieLogger).logExpr(theory1.statement);
-		(theory2.conclusion ? factLogger : lieLogger).logExpr(theory2.statement);
-	}
-}
-```
+
+[code asset](assets/InstanceExprArgUsage.hx)
+
 This outputs at runtime:
 ```
 Test.hx:9: Fact: theory1.statement = [Haxe is great!]

--- a/content/09-macro.md
+++ b/content/09-macro.md
@@ -91,7 +91,7 @@ If the final argument of a macro is of type `Array<Expr>`, the macro accepts an 
 
 
 <!--label:macro-instance-arg-->
-#### Instance argument
+#### Instance Argument
 
 If the macro is an instance method, the first arg will be the expression used to reference the instance:
 

--- a/content/09-macro.md
+++ b/content/09-macro.md
@@ -89,8 +89,64 @@ If the final argument of a macro is of type `Array<Expr>`, the macro accepts an 
 [code asset](assets/MacroArgumentsRest.hx)
 
 
+<!--label:macro-instance-arg-->
+#### Instance argument
 
+If the macro is an instance method, the first arg will be the expression used to reference the instance:
 
+```haxe
+import haxe.macro.Expr;
+import haxe.macro.ExprTools;
+import haxe.macro.MacroStringTools;
+
+// use this for macros or other classes
+class Logger {
+	public final id:String;
+	public function new(id:String) {
+		this.id = id;
+	}
+	
+	inline public function log(data:Any, logID:String, ?pos) {
+		haxe.Log.trace('$id: $logID = [$data]', pos);
+	}
+	
+	macro public function logExpr(inst:Expr, data:Expr):Expr {
+		return eval(inst, data);
+	}
+	
+	#if macro
+	static public function eval(inst:Expr, obj:Expr):Expr {
+		final str = MacroStringTools.formatString;
+		final id = str('${ExprTools.toString(obj)}', obj.pos);
+		
+		return macro {
+			@:pos(obj.pos)
+			$inst.log($obj, $id);
+		};
+	}
+	#end
+}
+```
+Usage:
+```haxe
+class Test {
+	static function main() {
+		final factLogger = new Logger("Fact");
+		final lieLogger = new Logger("Lie");
+		
+		final theory1 = {statement: "Haxe is great!", conclusion: true};
+		final theory2 = {statement: "7 > 9", conclusion: false};
+		
+		(theory1.conclusion ? factLogger : lieLogger).logExpr(theory1.statement);
+		(theory2.conclusion ? factLogger : lieLogger).logExpr(theory2.statement);
+	}
+}
+```
+This outputs at runtime:
+```
+Test.hx:9: Fact: theory1.statement = [Haxe is great!]
+Test.hx:10: Lie: theory2.statement = [7 > 9]
+```
 
 <!--label:macro-reification-->
 ### Reification


### PR DESCRIPTION
I couldn't find any mention of this, and it seems like an important, and somewhat ambiguous feature. This was the simplest example I could think of, while showing that the instance expression isn't limited to a simple identifier.

To be honest, this feature is still cryptic to me, is it static extension? I notice this doesn't work if eval is not static. Should this info be included?